### PR TITLE
Parser options should be optional

### DIFF
--- a/jquery.parse.js
+++ b/jquery.parse.js
@@ -112,6 +112,9 @@
 
 	$.parse = function(input, options)
 	{
+		if (!options)
+			options = {};
+
 		var parser = new Parser(options);
 		return parser.parse(input);
 	};


### PR DESCRIPTION
The documentation states that the `options` argument of `$.parse()` is optional, but it cleary wasn't ("TypeError: Cannot read property 'delimiter' of undefined").

I have not bumped the version nor updated the minified version since I didn't see any workflow for it.
