### PR TITLE
Fix bug in guessDelimiter()

### DIFF
--- a/jquery.parse.js
+++ b/jquery.parse.js
@@ -325,6 +325,7 @@
 			{
 				var delim = delimiters[i];
 				var delta = 0, avgFieldCount = 0;
+				var fieldCountPrevRow = undefined;
 
 				var preview = new Parser({
 					delimiter: delim,


### PR DESCRIPTION
While looping through the set of delimiters fieldCountPrevRow wasn't reseted. That led to some problems because fieldCountPrevRow was handed over between the runs.

No big change.
