### PR TITLE
Support webkitSlice if slice is not available

### DIFF
--- a/jquery.parse.js
+++ b/jquery.parse.js
@@ -196,7 +196,15 @@
 		{
 			if (start < file.size)
 			{
-				reader.readAsText(file.slice(start, Math.min(start + settings.chunkSize, file.size)), settings.config.encoding);
+				var end = Math.min(start + settings.chunkSize, file.size);
+
+				if (file.slice) {
+					reader.readAsText(file.slice(start, end), settings.config.encoding);
+				}
+				else if (file.webkitSlice) {
+					reader.readAsText(file.webkitSlice(start, end), settings.config.encoding);
+				}
+
 				start += settings.chunkSize;
 			}
 		};


### PR DESCRIPTION
I found this issue when I was testing a functionality that uses stream parsing with `capybara-webkit`.

If `file.slice` is not present, use `file.webkitSlice`.

See this [reference](https://github.com/blueimp/jQuery-File-Upload/issues/1704).

For some reason, `slice = file.slice || file.webkitSlice` does not work, so that's why the implementation looks awkward.
