### PR TITLE
If server doesn't support Content-Range, use Content-Length

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -507,7 +507,15 @@
 			function getFileSize(xhr)
 			{
 				var contentRange = xhr.getResponseHeader("Content-Range");
-				return parseInt(contentRange.substr(contentRange.lastIndexOf("/") + 1));
+				if (contentRange)
+				{
+					return parseInt(contentRange.substr(contentRange.lastIndexOf("/") + 1));
+				}
+				else
+				{
+					var contentLength = xhr.getResponseHeader("Content-Length");
+					return parseInt(contentLength);
+				}
 			}
 		};
 	}


### PR DESCRIPTION
If server isn't support Content-Range (ex, python SimpleHTTPServer), PapaParse will stop in getFileSize function.
This patch use Content-Length instead of Content-Range if server isn't support Content-Range.
