### PR TITLE
Allow tests to be run from subdirectories

### DIFF
--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -571,7 +571,7 @@ var PARSE_ASYNC_TESTS = [
 	},
 	{
 		description: "Simple download",
-		input: "/tests/sample.csv",
+		input: "sample.csv",
 		config: {
 			download: true
 		},
@@ -582,7 +582,7 @@ var PARSE_ASYNC_TESTS = [
 	},
 	{
 		description: "Simple download + worker",
-		input: "/tests/sample.csv",
+		input: "tests/sample.csv",
 		config: {
 			worker: true,
 			download: true


### PR DESCRIPTION
This fixes a bug where currently if you try and run tests.html from a subdirectory 

e.g. running /js/third_party/papaparse/tests/tests.html 

the 2 tests above will fail.
