### PR TITLE
can't insert papaparse in script tag

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1223,7 +1223,7 @@
 	function getScriptPath()
 	{
 		var id = "worker" + String(Math.random()).substr(2);
-		document.write('<script id="'+id+'"></script>');
+		document.write('<script id="'+id+'"></s'+'cript>');
 		return document.getElementById(id).previousSibling.src;
 	}
 


### PR DESCRIPTION
this line prevents to include papaparse in an HTML <script> tag
no harm to others
