### PR TITLE
Fixed broken complete callback when invoked via jQuery .parse() method

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -114,7 +114,7 @@
 				}
 
 				// Wrap up the user's complete callback, if any, so that ours also gets executed
-				var userCompleteFunc = f.instanceConfig.complete;
+				var userCompleteFunc = options.complete;
 				f.instanceConfig.complete = function(results)
 				{
 					if (isFunction(userCompleteFunc))


### PR DESCRIPTION
The prior code checked the wrong location to pull in the user-defined complete callback. I would have added a failing test to illustrate this, but it looks like you don't already have test coverage for the jquery plug-in.
