### PR TITLE
Remove document.write for script path and allow external config

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -156,16 +156,13 @@
 	{
 		AUTO_SCRIPT_PATH = getScriptPath();
 		// Check if the script was loaded synchronously
-		if ( document.body )
-		{
-			document.body.addEventListener('load', function () {
-				LOADED_SYNC = true;
-			}, true);
-		}
-		else
-		{
+		if ( !document.body ) {
 			// Body doesn't exist yet, must be synchronous
 			LOADED_SYNC = true;
+		} else {
+			document.addEventListener('DOMContentLoaded', function () {
+				LOADED_SYNC = true;
+			}, true);
 		}
 	}
 
@@ -175,7 +172,7 @@
 	function CsvToJson(_input, _config)
 	{
 		var config = IS_WORKER ? _config : copyAndValidateConfig(_config);
-		var useWorker = config.worker && Papa.WORKERS_SUPPORTED && (Papa.SCRIPT_PATH || AUTO_SCRIPT_PATH);
+		var useWorker = config.worker && Papa.WORKERS_SUPPORTED;
 
 		if (useWorker)
 		{


### PR DESCRIPTION
1. Use document.getElementsByTag name to find the script's path.
   When used async, this fails by providing the wrong path instead
   of failing catastrophically.
2. Detect if the script was loaded asynchronously by attaching a load
   event to the body and seeing if it fires.
3. Evaluate the correct script path when it is requested. This gives
   the user time to manually configuring it using the Papa.SCRIPT_PATH
   global. If this isn't done and the script was loaded async, throw
   a helpful error explaining how to fix.

Fixes #119
