### PR TITLE
Module loading

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -34,8 +34,13 @@
 	Papa.FileStreamer = FileStreamer;
 	Papa.StringStreamer = StringStreamer;
 
+	// export to Node...
+	if (typeof module !== 'undefined' && module.exports) {
+		module.exports = Papa;
+	}
+
 	// Wireup with RequireJS
-	if (isFunction(global.define) && global.define.amd)
+	else if (isFunction(global.define) && global.define.amd)
 	{
 		global.define(function() { return Papa; });
 	}

--- a/papaparse.js
+++ b/papaparse.js
@@ -10,33 +10,41 @@
 	var IS_WORKER = !global.document, LOADED_SYNC = false, AUTO_SCRIPT_PATH;
 	var workers = {}, workerIdCounter = 0;
 
-	global.Papa = {};
+	var Papa = {};
 
-	global.Papa.parse = CsvToJson;
-	global.Papa.unparse = JsonToCsv;
+	Papa.parse = CsvToJson;
+	Papa.unparse = JsonToCsv;
 
-	global.Papa.RECORD_SEP = String.fromCharCode(30);
-	global.Papa.UNIT_SEP = String.fromCharCode(31);
-	global.Papa.BYTE_ORDER_MARK = "\ufeff";
-	global.Papa.BAD_DELIMITERS = ["\r", "\n", "\"", global.Papa.BYTE_ORDER_MARK];
-	global.Papa.WORKERS_SUPPORTED = !!global.Worker;
-	global.Papa.SCRIPT_PATH = null;	// Must be set by your code if you use workers and this lib is loaded asynchronously
+	Papa.RECORD_SEP = String.fromCharCode(30);
+	Papa.UNIT_SEP = String.fromCharCode(31);
+	Papa.BYTE_ORDER_MARK = "\ufeff";
+	Papa.BAD_DELIMITERS = ["\r", "\n", "\"", Papa.BYTE_ORDER_MARK];
+	Papa.WORKERS_SUPPORTED = !!global.Worker;
+	Papa.SCRIPT_PATH = null;	// Must be set by your code if you use workers and this lib is loaded asynchronously
 
 	// Configurable chunk sizes for local and remote files, respectively
-	global.Papa.LocalChunkSize = 1024 * 1024 * 10;	// 10 MB
-	global.Papa.RemoteChunkSize = 1024 * 1024 * 5;	// 5 MB
-	global.Papa.DefaultDelimiter = ",";				// Used if not specified and detection fails
+	Papa.LocalChunkSize = 1024 * 1024 * 10;	// 10 MB
+	Papa.RemoteChunkSize = 1024 * 1024 * 5;	// 5 MB
+	Papa.DefaultDelimiter = ",";				// Used if not specified and detection fails
 
 	// Exposed for testing and development only
-	global.Papa.Parser = Parser;
-	global.Papa.ParserHandle = ParserHandle;
-	global.Papa.NetworkStreamer = NetworkStreamer;
-	global.Papa.FileStreamer = FileStreamer;
-	global.Papa.StringStreamer = StringStreamer;
+	Papa.Parser = Parser;
+	Papa.ParserHandle = ParserHandle;
+	Papa.NetworkStreamer = NetworkStreamer;
+	Papa.FileStreamer = FileStreamer;
+	Papa.StringStreamer = StringStreamer;
 
 	// Wireup with RequireJS
 	if (isFunction(global.define) && global.define.amd)
-	    global.define(function() { return global.Papa; });
+	{
+		global.define(function() { return Papa; });
+	}
+
+	// ...or as browser global
+	else
+	{
+		global.Papa = Papa;
+	}
 
 	if (global.jQuery)
 	{
@@ -257,7 +265,7 @@
 
 			if (typeof _config.delimiter === 'string'
 				&& _config.delimiter.length == 1
-				&& global.Papa.BAD_DELIMITERS.indexOf(_config.delimiter) == -1)
+				&& Papa.BAD_DELIMITERS.indexOf(_config.delimiter) == -1)
 			{
 				_delimiter = _config.delimiter;
 			}
@@ -338,7 +346,7 @@
 
 			var needsQuotes = (typeof _quotes === 'boolean' && _quotes)
 							|| (_quotes instanceof Array && _quotes[col])
-							|| hasAny(str, global.Papa.BAD_DELIMITERS)
+							|| hasAny(str, Papa.BAD_DELIMITERS)
 							|| str.indexOf(_delimiter) > -1
 							|| str.charAt(0) == ' '
 							|| str.charAt(str.length - 1) == ' ';

--- a/papaparse.js
+++ b/papaparse.js
@@ -1334,4 +1334,4 @@
 	{
 		return typeof func === 'function';
 	}
-})(this);
+})(typeof window !== 'undefined' ? window : this);

--- a/papaparse.js
+++ b/papaparse.js
@@ -7,7 +7,7 @@
 {
 	"use strict";
 
-	var IS_WORKER = !global.document, LOADED_SYNC = false, AUTO_SCRIPT_PATH;
+	var IS_WORKER = (!global.document && !!global.postMessage), LOADED_SYNC = false, AUTO_SCRIPT_PATH;
 	var workers = {}, workerIdCounter = 0;
 
 	var Papa = {};

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -1,0 +1,52 @@
+(function() {
+	"use strict";
+
+	var Papa = require("../papaparse.js");
+
+	var fs = require('fs');
+	var assert = require('assert');
+	var longSampleRawCsv = fs.readFileSync(__dirname + '/long-sample.csv', 'utf8');
+
+	function assertLongSampleParsedCorrectly(parsedCsv) {
+		assert.equal(8, parsedCsv.data.length)
+		assert.deepEqual(parsedCsv.data[0], [
+			'Grant',
+			'Dyer',
+			'Donec.elementum@orciluctuset.example',
+			'2013-11-23T02:30:31-08:00',
+			'2014-05-31T01:06:56-07:00',
+			'Magna Ut Associates',
+			'ljenkins'
+		])
+		assert.deepEqual(parsedCsv.data[7], [
+			'Talon',
+			'Salinas',
+			'posuere.vulputate.lacus@Donecsollicitudin.example',
+			'2015-01-31T09:19:02-08:00',
+			'2014-12-17T04:59:18-08:00',
+			'Aliquam Iaculis Incorporate',
+			'Phasellus@Quisquetincidunt.example'
+		]);
+		assert.deepEqual(parsedCsv.meta, {
+			"delimiter":",",
+			"linebreak":"\n",
+			"aborted":false,
+			"truncated":false,
+			"cursor":1209
+		});
+		assert.equal(parsedCsv.errors.length, 0)
+	}
+
+	var synchronouslyParsedCsvShouldBeCorrectlyParsed = function() {
+		assertLongSampleParsedCorrectly(Papa.parse(longSampleRawCsv));
+	}();
+
+	var asynchronouslyParsedCsvShouldBeCorrectlyParsed = function() {
+		Papa.parse(longSampleRawCsv, {
+			complete: function(parsedCsv) {
+				assertLongSampleParsedCorrectly(parsedCsv);
+			},
+		});
+	}();
+
+})();

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,3 +1,5 @@
+require('./node-tests.js');
+
 var connect = require('connect');
 var serveStatic = require('serve-static');
 var open = require('open');


### PR DESCRIPTION
Further to discussions in #167, this PR adds support for loading PapaParse as a module. It adds basic automated tests for loading as a node js module (although some options will not work eg remote file parsing, web workers etc). It also adds support for loading via RequireJS (untested) and WebPack (manually tested). Finally, it stops PapaParse from being added into the global context (ie window) when loaded as a module.
