### PR TITLE
fixed support for aborting parsing

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -390,7 +390,7 @@
 
 			var results = this._handle.parse(aggregate, this._baseIndex, !this._finished);
 			
-			if (this._handle.paused())
+			if (this._handle.paused() || this._handle.aborted())
 				return;
 			
 			var lastIndex = results.meta.cursor;
@@ -658,6 +658,7 @@
 		var _input;				// The input being parsed
 		var _parser;			// The core parser being used
 		var _paused = false;	// Whether we are paused or not
+		var _aborted = false;   // Whether the parser has aborted or not
 		var _delimiterError;	// Temporary state between delimiter detection and processing results
 		var _fields = [];		// Fields are from the header row of the input, if there is one
 		var _results = {		// The last results returned from the parser
@@ -743,8 +744,13 @@
 			self.streamer.parseChunk(_input);
 		};
 
+		this.aborted = function () {
+			return _aborted;
+		}
+
 		this.abort = function()
 		{
+			_aborted = true;
 			_parser.abort();
 			if (isFunction(_config.complete))
 				_config.complete(_results);

--- a/papaparse.js
+++ b/papaparse.js
@@ -752,6 +752,7 @@
 		{
 			_aborted = true;
 			_parser.abort();
+			_results.meta.aborted = true;
 			if (isFunction(_config.complete))
 				_config.complete(_results);
 			_input = "";

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1234,6 +1234,22 @@ var CUSTOM_TESTS = [
 		}
 	},
 	{
+		description: "Complete is called after aborting",
+		expected: true,
+		run: function(callback) {
+			var updates = [];
+			Papa.parse('A,b,c\nd,E,f\nG,h,i', {
+				step: function(response, handle) {
+					handle.abort();
+				},
+				chunkSize: 6,
+				complete: function (response) {
+					callback(response.meta.aborted);
+				}
+			});
+		}
+	},
+	{
 		description: "Step functions can pause parsing",
 		expected: [['A', 'b', 'c']],
 		run: function(callback) {

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1227,10 +1227,9 @@ var CUSTOM_TESTS = [
 				step: function(response, handle) {
 					updates.push(response.data[0]);
 					handle.abort();
-				},
-				complete: function() {
 					callback(updates);
-				}
+				},
+				chunkSize: 6
 			});
 		}
 	},


### PR DESCRIPTION
I was using PapaParse to parse through a large CSV file recently, and wanted to make use of the ParseHandle's abort method. However, despite calling abort(), the parser continued to run. Following the pattern for pausing the parser, I attempted to flesh out support for calling abort. From what I could tell, there just wasn't a variable in place for abort() like there is for pause(). 

The original test case seemed to pass regardless of whether or not abort() was working, because the string provided was being parsed in a single go. Hence, the callback was only called once no matter what. I included the chunkSize on the config to make the test parse the string in pieces. Now, the test does indeed fail when abort() is not working, and passes when it does work.

Feedback is welcome.