### PR TITLE
read files in a single chunk for complete results (#179)

### DIFF
--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1042,6 +1042,18 @@ var UNPARSE_TESTS = [
 
 var CUSTOM_TESTS = [
 	{
+		description: "Complete is called with all results if neither step nor chunk is defined",
+		expected: [['A', 'b', 'c'], ['d', 'E', 'f'], ['G', 'h', 'i']],
+		run: function(callback) {
+			Papa.parse(new File(['A,b,c\nd,E,f\nG,h,i'], 'sample.csv'), {
+				chunkSize: 3,
+				complete: function(response) {
+					callback(response.data);
+				}
+			});
+		}
+	},
+	{
 		description: "Step is called for each row",
 		expected: 2,
 		run: function(callback) {


### PR DESCRIPTION
This restores the unchunked read previously present in https://github.com/mholt/PapaParse/commit/57a7349c41502afff0328bab918d0e10f8b8fd80#commitcomment-10179215 .