### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
 		"jquery-plugin"
 	],
 	"homepage": "http://papaparse.com",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/mholt/PapaParse.git"
+	},
 	"author": {
 		"name": "Matthew Holt",
 		"url": "https://twitter.com/mholt6"


### PR DESCRIPTION
This removes the "No repository field." warning from npm.