### PR TITLE
Fix newline option for delimiter autodetect

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -750,7 +750,7 @@
 			_delimiterError = false;
 			if (!_config.delimiter)
 			{
-				var delimGuess = guessDelimiter(input);
+				var delimGuess = guessDelimiter(input, _config.newline);
 				if (delimGuess.successful)
 					_config.delimiter = delimGuess.bestDelimiter;
 				else
@@ -890,7 +890,7 @@
 			return _results;
 		}
 
-		function guessDelimiter(input)
+		function guessDelimiter(input, newline)
 		{
 			var delimChoices = [',', '\t', '|', ';', Papa.RECORD_SEP, Papa.UNIT_SEP];
 			var bestDelim, bestDelta, fieldCountPrevRow;
@@ -903,6 +903,7 @@
 
 				var preview = new Parser({
 					delimiter: delim,
+					newline: newline,
 					preview: 10
 				}).parse(input);
 


### PR DESCRIPTION
In function guessDelimiter always used '\n' as newline. This pull request fix it.