### PR TITLE
Fixes auto detecting mixed line endings

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -949,7 +949,11 @@
 
 			var r = input.split('\r');
 
-			if (r.length === 1)
+			var n = input.split('\n');
+
+			var nAppearsFirst = (n.length > 1 && n[0].length < r[0].length);
+
+			if (r.length === 1 || nAppearsFirst)
 				return '\n';
 
 			var numWithN = 0;

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -508,6 +508,14 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Mixed slash n and slash r should choose first as precident",
+		input: 'a,b,c\nd,e,f\rg,h,i\n',
+		expected: {
+			data: [['a', 'b', 'c'], ['d', 'e', 'f\rg', 'h', 'i'], ['']],
+			errors: []
+		}
+	},
+	{
 		description: "Header row with one row of data",
 		input: 'A,B,C\r\na,b,c',
 		config: { header: true },


### PR DESCRIPTION
This stems from a production issue we faced while using PapaParse.  Customers had uploaded data with mixed line endings (likely due to a concat from different systems).  We were most interested in extracting header info, so this fix was better than the current guessing mechanism.  Still room for improvement.