### PR TITLE
Fix for complete(res, file) in parse(file, ...)

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -455,7 +455,7 @@
 			}
 
 			if (finishedIncludingPreview && isFunction(this._config.complete) && (!results || !results.meta.aborted))
-				this._config.complete(this._completeResults);
+				this._config.complete(this._completeResults, this._input);
 
 			if (!finishedIncludingPreview && (!results || !results.meta.paused))
 				this._nextChunk();


### PR DESCRIPTION
Fix the "complete(res, file)" for parse(file, ...) so that "file" is not undefined in "complete". Works for the tested case, but it is not clear if this might cause problems with other "Streamed" reading modes.