### PR TITLE
Add callback option for specifying delimiter.

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -764,6 +764,11 @@
 				}
 				_results.meta.delimiter = _config.delimiter;
 			}
+			else if(typeof _config.delimiter === 'function')
+			{
+				_config.delimiter = _config.delimiter(input);
+				_results.meta.delimiter = _config.delimiter;
+			}
 
 			var parserConfig = copy(_config);
 			if (_config.preview && _config.header)

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -626,6 +626,15 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Callback delimiter",
+		input: 'a$ b$ c',
+		config: { delimiter: function(input) { return input[1] + ' '; } },
+		expected: {
+			data: [['a', 'b', 'c']],
+			errors: []
+		}
+	},
+	{
 		description: "Dynamic typing converts numeric literals",
 		input: '1,2.2,1e3\r\n-4,-4.5,-4e-5\r\n-,5a,5-2',
 		config: { dynamicTyping: true },


### PR DESCRIPTION
I noticed there are some difficulties with auto-detecting delimiters (best described at https://github.com/mholt/PapaParse/issues/153 & https://github.com/mholt/PapaParse/issues/290).

I've faced similar issues, but I can't follow the suggestion of specifying the delimiter every time, because I don't know it before parsing the file.

However I do, in my case, have a good idea of what structure the data will be in - for example I always expect the first cell to be empty (and can handle the errors arising from that ever not being true).

This lead me to the idea of allowing a callback to be used to determine the delimiter, based on the parsed file content (before it is parsed to CSV). This lets me simply return the first character of the input to specify the delimiter, rather than having to hard-code it or rely on auto-detection.

Let me know if you think this is an acceptable solution, and if it can be improved in anyway.
