### PR TITLE
Add custom quote character to unparse

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -240,7 +240,12 @@
 		/** newline character(s) */
 		var _newline = '\r\n';
 
+		/** quote character */
+		var _quoteChar = '"';
+
 		unpackConfig();
+
+		var quoteCharRegex = new RegExp(_quoteChar, 'g');
 
 		if (typeof _input === 'string')
 			_input = JSON.parse(_input);
@@ -296,6 +301,9 @@
 
 			if (typeof _config.newline === 'string')
 				_newline = _config.newline;
+
+			if (typeof _config.quoteChar === 'string')
+				_quoteChar = _config.quoteChar;
 		}
 
 
@@ -362,7 +370,7 @@
 			if (typeof str === 'undefined' || str === null)
 				return '';
 
-			str = str.toString().replace(/"/g, '""');
+			str = str.toString().replace(quoteCharRegex, _quoteChar+_quoteChar);
 
 			var needsQuotes = (typeof _quotes === 'boolean' && _quotes)
 							|| (_quotes instanceof Array && _quotes[col])
@@ -371,7 +379,7 @@
 							|| str.charAt(0) === ' '
 							|| str.charAt(str.length - 1) === ' ';
 
-			return needsQuotes ? '"' + str + '"' : str;
+			return needsQuotes ? _quoteChar + str + _quoteChar : str;
 		}
 
 		function hasAny(str, substrings)

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -892,16 +892,16 @@ var PARSE_TESTS = [
 			errors: []
 		}
 	},
-    {
-        description: "Single quote as quote character",
-        notes: "Must parse correctly when single quote is specified as a quote character",
-        input: "a,b,'c,d'",
-        config: { quoteChar: "'"},
-        expected: {
-            data: [['a', 'b', 'c,d']],
-            errors: []
-        }
-    }
+	{
+		description: "Single quote as quote character",
+		notes: "Must parse correctly when single quote is specified as a quote character",
+		input: "a,b,'c,d'",
+		config: { quoteChar: "'"},
+		expected: {
+			data: [['a', 'b', 'c,d']],
+			errors: []
+		}
+	}
 ];
 
 describe('Parse Tests', function() {
@@ -1152,6 +1152,12 @@ var UNPARSE_TESTS = [
 		description: "JSON null is treated as empty value",
 		input: [{ "Col1": "a", "Col2": null, "Col3": "c" }],
 		expected: 'Col1,Col2,Col3\r\na,,c'
+	},
+	{
+		description: "Custom quote character (single quote)",
+		input: [['a,d','b','c']],
+		config: { quoteChar: "'"},
+		expected: "'a,d',b,c"
 	}
 ];
 


### PR DESCRIPTION
Allows specifying the quoteChar in config for unparse like:

``` javascript
Papa.unparse(data, {
  quoteChar: "'"
})
```
