### PR TITLE
Leading Zero As String

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -701,6 +701,7 @@
 	{
 		// One goal is to minimize the use of regular expressions...
 		var FLOAT = /^\s*-?(\d*\.?\d+|\d+\.?\d*)(e[-+]?\d+)?\s*$/i;
+		var LEADINGZERO = /^0[0-9].*$/;
 
 		var self = this;
 		var _stepCounter = 0;	// Number of times step was called (number of rows parsed)
@@ -983,7 +984,8 @@
 		function tryParseFloat(val)
 		{
 			var isNumber = FLOAT.test(val);
-			return isNumber ? parseFloat(val) : val;
+			var leadingZeroAsString = _config.leadingZeroAsString&&LEADINGZERO.test(val);
+			return isNumber&&!leadingZeroAsString ? parseFloat(val) : val;
 		}
 
 		function addError(type, code, msg, row)


### PR DESCRIPTION
When using dynamic typing, set the "leadingZeroAsString" config option to "true" in order to treat values with leading zeros as strings. Used the following RegEx logic:

var regExp = /^0[0-9].*$/
console.log(regExp.test("0001")); // true
console.log(regExp.test("001")); // true
console.log(regExp.test("01")); // true
console.log(regExp.test("00.12312")); // true
console.log(regExp.test("000.1232")); // true
console.log(regExp.test("1")); // false
console.log(regExp.test("20")); // false
console.log(regExp.test("0.1")); // false
console.log(regExp.test("0.123123")); // false
