### PR TITLE
No Content-Range, then finish with current data!

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -594,6 +594,9 @@
 		function getFileSize(xhr)
 		{
 			var contentRange = xhr.getResponseHeader('Content-Range');
+			if (contentRange === null) { // no content range, then finish!
+        			return -1;
+            		} 
 			return parseInt(contentRange.substr(contentRange.lastIndexOf('/') + 1));
 		}
 	}


### PR DESCRIPTION
I'd like to show the part of the data when there is no Content-Range header. This usually solves the case with gzip-compression and smaller file size.
