### PR TITLE
add ability to configure which columns are dynamically typed

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -426,6 +426,10 @@
 			this._isAllDynamic = true;
 			return;
 		}
+		else if (typeof config === 'function')
+		{
+			this._isIncluded = config;
+		}
 		else if (!config)
 		{
 			return;
@@ -456,6 +460,10 @@
 	DynamicTypingConfig.prototype.constructor = DynamicTypingConfig;
 	DynamicTypingConfig.prototype.isIncluded = function(field)
 	{
+		if (typeof this._isIncluded === 'function')
+		{
+			return this._isIncluded(field);
+		}
 		return this._isAllDynamic || this._columnConfig[field] === true || (this._isBlackListOnly && this._columnConfig[field] !== false)
 	};
 

--- a/papaparse.js
+++ b/papaparse.js
@@ -417,54 +417,20 @@
 
 	function DynamicTypingConfig(config)
 	{
-		this._columnConfig = {};
-		this._isAllDynamic = false;
-		this._isBlackListOnly = true;
-
-		if (config === true)
-		{
-			this._isAllDynamic = true;
-			return;
-		}
-		else if (typeof config === 'function')
-		{
-			this._isIncluded = config;
-		}
-		else if (!config)
-		{
-			return;
-		}
-
-		if (config.__only instanceof Array)
-		{
-			this._isBlackListOnly = false;
-			config.__only.forEach(function(field)
-			{
-				this._columnConfig[field] = true;
-			}.bind(this));
-		}
-		else
-		{
-			this._isBlackListOnly = !!config.__except;
-			this._columnConfig = config;
-		}
-
-		if (config.__except instanceof Array)
-		{
-			config.__except.forEach(function(field)
-			{
-				this._columnConfig[field] = false;
-			}.bind(this));
-		}
+		this._config = config;
 	}
 	DynamicTypingConfig.prototype.constructor = DynamicTypingConfig;
 	DynamicTypingConfig.prototype.isIncluded = function(field)
 	{
-		if (typeof this._isIncluded === 'function')
+		if (typeof this._config === 'function')
 		{
-			return this._isIncluded(field);
+			return this._config(field);
 		}
-		return this._isAllDynamic || this._columnConfig[field] === true || (this._isBlackListOnly && this._columnConfig[field] !== false)
+		if (typeof this._config === 'object')
+		{
+			return this._config[field] === true;
+		}
+		return !!this._config;
 	};
 
 	/** ChunkStreamer is the base prototype for various streamer implementations. */

--- a/papaparse.js
+++ b/papaparse.js
@@ -424,7 +424,7 @@
 	{
 		if (typeof this._config === 'function')
 		{
-			return this._config(field);
+			return this._config(field) === true;
 		}
 		if (typeof this._config === 'object')
 		{

--- a/papaparse.js
+++ b/papaparse.js
@@ -161,7 +161,7 @@
 				queue.splice(0, 1);
 				parseNextFile();
 			}
-		};
+		}
 	}
 
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -694,65 +694,11 @@ var PARSE_TESTS = [
 		}
 	},
 	{
-		description: "Dynamic typing can be applied to `__only` indices",
-		input: '001,002,003',
-		config: { dynamicTyping: { __only: [1] } },
-		expected: {
-			data: [["001", 2, "003"]],
-			errors: []
-		}
-	},
-	{
-		description: "Dynamic typing can be applied to all indices and not `__except` indices",
-		input: '001,002,003',
-		config: { dynamicTyping: { __except: [1] } },
-		expected: {
-			data: [[1, "002", 3]],
-			errors: []
-		}
-	},
-	{
-		description: "Dynamic typing can be applied to `__only` indices and not `__except` indices",
-		input: '001,002,003',
-		config: { dynamicTyping: { __only: [1, 2], __except: [1] } },
-		expected: {
-			data: [["001", "002", 3]],
-			errors: []
-		}
-	},
-	{
 		description: "Dynamic typing by indices can be determined by function",
 		input: '001,002,003',
 		config: { dynamicTyping: function(field) { return (field % 2) === 0; } },
 		expected: {
 			data: [[1, "002", 3]],
-			errors: []
-		}
-	},
-	{
-		description: "Dynamic typing can be applied to `__only` headers",
-		input: 'A,B,C\r\n001,002,003',
-		config: { header: true, dynamicTyping: { __only: ['B'] } },
-		expected: {
-			data: [{"A": "001", "B": 2, "C": "003"}],
-			errors: []
-		}
-	},
-	{
-		description: "Dynamic typing can be applied to all headers and not `__except` headers",
-		input: 'A,B,C\r\n001,002,003',
-		config: { header: true, dynamicTyping: { __except: ['B'] } },
-		expected: {
-			data: [{"A": 1, "B": "002", "C": 3}],
-			errors: []
-		}
-	},
-	{
-		description: "Dynamic typing can be applied to `__only` headers and not `__except` headers",
-		input: 'A,B,C\r\n001,002,003',
-		config: { header: true, dynamicTyping: { __only: ['B', 'C'], __except: ['B'] } },
-		expected: {
-			data: [{"A": "001", "B": "002", "C": 3}],
 			errors: []
 		}
 	},

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -694,6 +694,60 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Dynamic typing can be applied to `__only` indices",
+		input: '001,002,003',
+		config: { dynamicTyping: { __only: [1] } },
+		expected: {
+			data: [["001", 2, "003"]],
+			errors: []
+		}
+	},
+	{
+		description: "Dynamic typing can be applied to all indices and not `__except` indices",
+		input: '001,002,003',
+		config: { dynamicTyping: { __except: [1] } },
+		expected: {
+			data: [[1, "002", 3]],
+			errors: []
+		}
+	},
+	{
+		description: "Dynamic typing can be applied to `__only` indices and not `__except` indices",
+		input: '001,002,003',
+		config: { dynamicTyping: { __only: [1, 2], __except: [1] } },
+		expected: {
+			data: [["001", "002", 3]],
+			errors: []
+		}
+	},
+	{
+		description: "Dynamic typing can be applied to `__only` headers",
+		input: 'A,B,C\r\n001,002,003',
+		config: { header: true, dynamicTyping: { __only: ['B'] } },
+		expected: {
+			data: [{"A": "001", "B": 2, "C": "003"}],
+			errors: []
+		}
+	},
+	{
+		description: "Dynamic typing can be applied to all headers and not `__except` headers",
+		input: 'A,B,C\r\n001,002,003',
+		config: { header: true, dynamicTyping: { __except: ['B'] } },
+		expected: {
+			data: [{"A": 1, "B": "002", "C": 3}],
+			errors: []
+		}
+	},
+	{
+		description: "Dynamic typing can be applied to `__only` headers and not `__except` headers",
+		input: 'A,B,C\r\n001,002,003',
+		config: { header: true, dynamicTyping: { __only: ['B', 'C'], __except: ['B'] } },
+		expected: {
+			data: [{"A": "001", "B": "002", "C": 3}],
+			errors: []
+		}
+	},
+	{
 		description: "Blank line at beginning",
 		input: '\r\na,b,c\r\nd,e,f',
 		config: { newline: '\r\n' },

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -721,6 +721,15 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Dynamic typing by indices can be determined by function",
+		input: '001,002,003',
+		config: { dynamicTyping: function(field) { return (field % 2) === 0; } },
+		expected: {
+			data: [[1, "002", 3]],
+			errors: []
+		}
+	},
+	{
 		description: "Dynamic typing can be applied to `__only` headers",
 		input: 'A,B,C\r\n001,002,003',
 		config: { header: true, dynamicTyping: { __only: ['B'] } },
@@ -744,6 +753,15 @@ var PARSE_TESTS = [
 		config: { header: true, dynamicTyping: { __only: ['B', 'C'], __except: ['B'] } },
 		expected: {
 			data: [{"A": "001", "B": "002", "C": 3}],
+			errors: []
+		}
+	},
+	{
+		description: "Dynamic typing by headers can be determined by function",
+		input: 'A_as_int,B,C_as_int\r\n001,002,003',
+		config: { header: true, dynamicTyping: function(field) { return /_as_int$/.test(field); } },
+		expected: {
+			data: [{"A_as_int": 1, "B": "002", "C_as_int": 3}],
 			errors: []
 		}
 	},


### PR DESCRIPTION
Goals are similar to #332.

- supports configuring `dynamicTyping` with a callback, giving more flexibility on what to dynamically type without needing to be strict on the fields you want to configure

See tests for usage/examples.