### PR TITLE
Better recognition of node commonJS

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -11,7 +11,7 @@
 		// AMD. Register as an anonymous module.
 		define([], factory);
 	}
-	else if (typeof module === 'object' && module.exports)
+	else if (typeof module === 'object' && typeof exports !== 'undefined')
 	{
 		// Node. Does not work with strict CommonJS, but
 		// only CommonJS-like environments that support module.exports,


### PR DESCRIPTION
resolves #391, tested with chrome (59.0.3051.3), safari (10.0.2), electron (1.6.10), Legacy node (0.12.14), LTS node (6.10.3) and current node (8.0.0)