### PR TITLE
Support for user-configuration of multiple potential delimiters

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -876,9 +876,9 @@
 				_config.newline = guessLineEndings(input);
 
 			_delimiterError = false;
-			if (!_config.delimiter)
+			if (!_config.delimiter || isArray(_config.delimiter))
 			{
-				var delimGuess = guessDelimiter(input, _config.newline);
+				var delimGuess = guessDelimiter(input, _config.newline, _config.delimiter);
 				if (delimGuess.successful)
 					_config.delimiter = delimGuess.bestDelimiter;
 				else
@@ -1040,10 +1040,14 @@
 			return _results;
 		}
 
-		function guessDelimiter(input, newline)
+		function guessDelimiter(input, newline, customDelimChoices)
 		{
-			var delimChoices = [',', '\t', '|', ';', Papa.RECORD_SEP, Papa.UNIT_SEP];
-			var bestDelim, bestDelta, fieldCountPrevRow;
+			var bestDelim, bestDelta, delimChoices, fieldCountPrevRow;
+
+			if (!customDelimChoices)
+				delimChoices = [',', '\t', '|', ';', Papa.RECORD_SEP, Papa.UNIT_SEP];
+			else
+				delimChoices = customDelimChoices;
 
 			for (var i = 0; i < delimChoices.length; i++)
 			{
@@ -1564,6 +1568,11 @@
 	function isFunction(func)
 	{
 		return typeof func === 'function';
+	}
+
+	function isArray(arr)
+	{
+		return Object.prototype.toString.call(arr) === '[object Array]';
 	}
 
 	return Papa;

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -635,6 +635,24 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Custom array of potential delimiters",
+		input: "a\t,b\t,c\t",
+		config: { delimiter: ['|', ';', ','] },
+		expected: {
+			data: [["a\t", "b\t", "c\t"]],
+			errors: []
+		}
+	},
+	{
+		description: "Custom delimiter array, correctly guesses most prevalent one",
+		input: 'a;%b,%c,%d;',
+		config: { delimiter: ['%', ',', ';'] },
+		expected: {
+			data: [['a;', 'b,', 'c,', 'd;']],
+			errors: []
+		}
+	},
+	{
 		description: "Dynamic typing converts numeric literals",
 		input: '1,2.2,1e3\r\n-4,-4.5,-4e-5\r\n-,5a,5-2',
 		config: { dynamicTyping: true },


### PR DESCRIPTION
* Currently the 'delimiter' config option lets the user either specify
  the exact specific expected delimiter or pass in a function that
  entirely overrides PapaParse's delimiter-guessing function. I have a
  use-case where I want to use the built-in guessing function, but
  with a restricted set of potential delimiters rather than the default
  set. I imagine other users may also want to restrict this set, or
  otherwise customize it to only consider certain delimiters (such as
  unusual delimiters not currently in the default set).
* This change enables a third option for the 'delimiter' config setting,
  other than a string or function-- if the user passes in an array of
  strings, then that array will be used as the set of potential
  delimiters for the built-in guessing function.