### PR TITLE
Make skipEmptyLines skip rows full of empty values

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -949,7 +949,7 @@
 			if (_config.skipEmptyLines)
 			{
 				for (var i = 0; i < _results.data.length; i++)
-					if (_results.data[i].length === 1 && _results.data[i][0] === '')
+					if (Object.values(_results.data[i]).join('').length === 0)
 						_results.data.splice(i--, 1);
 			}
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1047,6 +1047,26 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Skip lines with only empty values",
+		notes: "",
+		input: 'a,b\nc,d\n,\n,\n',
+		config: { header: true, skipEmptyLines: true},
+		expected: {
+			data: [{'a': 'c', 'b': 'd'}],
+			errors: []
+		}
+	},
+	{
+		description: "Skip lines with only empty values",
+		notes: "",
+		input: 'a,b\nc,d\n,\n,\n',
+		config: { skipEmptyLines: true},
+		expected: {
+			data: [['a', 'b'], ['c', 'd']],
+			errors: []
+		}
+	},
+	{
 		description: "Single quote as quote character",
 		notes: "Must parse correctly when single quote is specified as a quote character",
 		input: "a,b,'c,d'",


### PR DESCRIPTION
Currently, skipEmptyLines only skips lines with no content but for the
new line character. Lines with nothing but the delimiters and the new
line character are just as useless, so skip these too make sense.