### PR TITLE
Make skipEmptyLines skip rows full of empty values

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -946,10 +946,13 @@
 				_delimiterError = false;
 			}
 
-			if (_config.skipEmptyLines)
+			if (_config.skipEmptyLines || _config.skipNullLines)
 			{
 				for (var i = 0; i < _results.data.length; i++)
-					if (isEmptyLine(_results.data[i]))
+					if (
+						(_config.skipEmptyLines && isEmptyLine(_results.data[i])) ||
+						(_config.skipNullLines && isNullLine(_results.data[i]))
+					)
 						_results.data.splice(i--, 1);
 			}
 
@@ -1059,11 +1062,14 @@
 
 				for (var j = 0; j < preview.data.length; j++)
 				{
-					if (_config.skipEmptyLines && isEmptyLine(preview.data[j]))
-					{
+					if (
+						(_config.skipEmptyLines && isEmptyLine(preview.data[j])) ||
+						(_config.skipNullLines && isNullLine(preview.data[j]))
+					) {
 						emptyLinesCount++;
 						continue;
 					}
+
 					var fieldCount = preview.data[j].length;
 					avgFieldCount += fieldCount;
 
@@ -1124,6 +1130,17 @@
 		function isEmptyLine(line)
 		{
 			return line.length === 1 && line[0].length === 0;
+		}
+
+		function isNullLine(line)
+		{
+			for (var prop in line)
+			{
+				if (line.hasOwnProperty(prop) && line[prop].length > 0)
+					return false;
+			}
+
+			return true;
 		}
 
 		function tryParseFloat(val)

--- a/papaparse.js
+++ b/papaparse.js
@@ -949,7 +949,7 @@
 			if (_config.skipEmptyLines)
 			{
 				for (var i = 0; i < _results.data.length; i++)
-					if (_results.data[i].length === 1 && _results.data[i][0] === '')
+					if (isEmptyLine(_results.data[i]))
 						_results.data.splice(i--, 1);
 			}
 
@@ -1059,9 +1059,10 @@
 
 				for (var j = 0; j < preview.data.length; j++)
 				{
-					if (skipEmptyLines && preview.data[j].length === 1 && preview.data[j][0].length === 0) {
-						emptyLinesCount++
-						continue
+					if (_config.skipEmptyLines && isEmptyLine(preview.data[j]))
+					{
+						emptyLinesCount++;
+						continue;
 					}
 					var fieldCount = preview.data[j].length;
 					avgFieldCount += fieldCount;
@@ -1118,6 +1119,11 @@
 			}
 
 			return numWithN >= r.length / 2 ? '\r\n' : '\r';
+		}
+
+		function isEmptyLine(line)
+		{
+			return line.length === 1 && line[0].length === 0;
 		}
 
 		function tryParseFloat(val)

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1003,6 +1003,15 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Skip all empty lines",
+		input: 'a,b,c\n\n\n\nd,e,f',
+		config: { skipEmptyLines: true },
+		expected: {
+			data: [['a', 'b', 'c'], ['d', 'e', 'f']],
+			errors: []
+		}
+	},
+	{
 		description: "Skip empty lines, with newline at end of input",
 		input: 'a,b,c\r\n\r\nd,e,f\r\n',
 		config: { skipEmptyLines: true },

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1056,6 +1056,36 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Null lines remain unaffected by 'skip empty lines' config",
+		notes: "",
+		input: 'a,b\nc,d\n\n,\n',
+		config: { skipEmptyLines: true },
+		expected: {
+			data: [['a', 'b'], ['c', 'd'], ["", ""]],
+			errors: []
+		}
+	},
+	{
+		description: "Skip null lines with only empty values",
+		notes: "",
+		input: 'a,b\nc,d\n,\n,\n',
+		config: { skipNullLines: true },
+		expected: {
+			data: [['a', 'b'], ['c', 'd']],
+			errors: []
+		}
+	},
+	{
+		description: "Skip null lines and empty lines work well with each other",
+		notes: "",
+		input: 'a,b\n,\n\nc,d',
+		config: { skipNullLines: true, skipEmptyLines: true },
+		expected: {
+			data: [['a', 'b'], ['c', 'd']],
+			errors: []
+		}
+	},
+	{
 		description: "Single quote as quote character",
 		notes: "Must parse correctly when single quote is specified as a quote character",
 		input: "a,b,'c,d'",

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1056,7 +1056,7 @@ var PARSE_TESTS = [
 		}
 	},
 	{
-		description: "Null lines remain unaffected by 'skip empty lines' config",
+		description: "Empty fields lines remain unaffected by 'skip empty lines' config",
 		notes: "",
 		input: 'a,b\nc,d\n\n,\n',
 		config: { skipEmptyLines: true },
@@ -1066,20 +1066,20 @@ var PARSE_TESTS = [
 		}
 	},
 	{
-		description: "Skip null lines with only empty values",
+		description: "Skip lines with only empty fields",
 		notes: "",
 		input: 'a,b\nc,d\n,\n,\n',
-		config: { skipNullLines: true },
+		config: { skipEmptyFieldsLines: true },
 		expected: {
 			data: [['a', 'b'], ['c', 'd']],
 			errors: []
 		}
 	},
 	{
-		description: "Skip null lines and empty lines work well with each other",
+		description: "Skipping empty fields lines and empty lines work well with each other",
 		notes: "",
 		input: 'a,b\n,\n\nc,d',
-		config: { skipNullLines: true, skipEmptyLines: true },
+		config: { skipEmptyFieldsLines: true, skipEmptyLines: true },
 		expected: {
 			data: [['a', 'b'], ['c', 'd']],
 			errors: []

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1076,6 +1076,16 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "skipEmptyFieldsLines leaves empty lines alone",
+		notes: "",
+		input: 'a,b\n\nc,d',
+		config: { skipEmptyFieldsLines: true },
+		expected: {
+			data: [['a', 'b'], [], ['c', 'd']],
+			errors: []
+		}
+	},
+	{
 		description: "Skipping empty fields lines and empty lines work well with each other",
 		notes: "",
 		input: 'a,b\n,\n\nc,d',


### PR DESCRIPTION
Currently, skipEmptyLines only skips lines with no content but for the
new line character. Lines with nothing but the delimiters and the new
line character are just as useless, so skipping these too makes sense.