### PR TITLE
Add option to configure escape character (#459)

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1158,6 +1158,10 @@
 		} else {
 			var quoteChar = config.quoteChar;
 		}
+		var escapeChar = quoteChar;
+		if (config.escapeChar !== undefined){
+			escapeChar = config.escapeChar;
+		}
 
 		// Delimiter must be valid
 		if (typeof delim !== 'string'
@@ -1236,7 +1240,7 @@
 
 			var nextDelim = input.indexOf(delim, cursor);
 			var nextNewline = input.indexOf(newline, cursor);
-			var quoteCharRegex = new RegExp(quoteChar+quoteChar, 'g');
+			var quoteCharRegex = new RegExp(escapeChar.replace('\\', '\\\\')+quoteChar, 'g');
 
 			// Parser loop
 			for (;;)
@@ -1279,9 +1283,16 @@
 						}
 
 						// If this quote is escaped, it's part of the data; skip it
-						if (input[quoteSearch+1] === quoteChar)
+						// If the quote character is the escape character, then check if the next character is the escape character
+						if (quoteChar === escapeChar &&  input[quoteSearch+1] === escapeChar)
 						{
 							quoteSearch++;
+							continue;
+						}
+
+						// If the quote character is not the escape character, then check if the previous character was the escape character
+						if (quoteChar !== escapeChar && quoteSearch !== 0 && input[quoteSearch-1] === escapeChar)
+						{
 							continue;
 						}
 

--- a/papaparse.js
+++ b/papaparse.js
@@ -1240,7 +1240,7 @@
 
 			var nextDelim = input.indexOf(delim, cursor);
 			var nextNewline = input.indexOf(newline, cursor);
-			var quoteCharRegex = new RegExp(escapeChar.replace('\\', '\\\\')+quoteChar, 'g');
+			var quoteCharRegex = new RegExp(escapeChar.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')+quoteChar, 'g');
 
 			// Parser loop
 			for (;;)

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1101,6 +1101,16 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Custom escape character not used for escaping",
+		notes: "Must parse correctly if the backslash sign (\\) is configured as a custom escape character and appears as regular character in the text",
+		input: 'a,b,"c\\d"',
+		config: { escapeChar:'\\'},
+		expected: {
+			data: [['a', 'b', 'c\\d']],
+			errors: []
+		}
+	},
+	{
 		description: "Header row with preceding comment",
 		notes: "Must parse correctly headers if they are preceded by comments",
 		input: '#Comment\na,b\nc,d\n',

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1081,6 +1081,26 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Custom escape character in the middle",
+		notes: "Must parse correctly if the backslash sign (\\) is configured as a custom escape character",
+		input: 'a,b,"c\\"d\\"f"',
+		config: { escapeChar:'\\'},
+		expected: {
+			data: [['a', 'b', 'c"d"f']],
+			errors: []
+		}
+	},
+	{
+		description: "Custom escape character at the end",
+		notes: "Must parse correctly if the backslash sign (\\) is configured as a custom escape character and the escaped quote character appears at the end of the column",
+		input: 'a,b,"c\\"d\\""',
+		config: { escapeChar:'\\'},
+		expected: {
+			data: [['a', 'b', 'c"d"']],
+			errors: []
+		}
+	},
+	{
 		description: "Header row with preceding comment",
 		notes: "Must parse correctly headers if they are preceded by comments",
 		input: '#Comment\na,b\nc,d\n',


### PR DESCRIPTION
This pull request adds the optional configuration option `escapeChar` to escape the `quoteChar` in a quoted field. This option allows to parse CSV files where a non-standard escape character is used. (p.E. `\"` instead of `""`) .

If `escapeChar` is provided, it may contain a one character long string.
If `escapeChar` is not provided, the `quoteChar` will be used as fallback.
The `escapeChar` must appear before the `quoteChar`.

Two tests have been added to validate the functionality of this feature.
Solves issue #459.