### PR TITLE
Pass full error object on stream errors

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -637,7 +637,7 @@
 		this._chunkError = function(errorMessage)
 		{
 			var errorText = xhr.statusText || errorMessage;
-			this._sendError(errorText);
+			this._sendError(new Error(errorText));
 		}
 
 		function getFileSize(xhr)
@@ -712,7 +712,7 @@
 
 		this._chunkError = function()
 		{
-			this._sendError(reader.error.message);
+			this._sendError(reader.error);
 		}
 
 	}
@@ -798,7 +798,7 @@
 		this._streamError = bindFunction(function(error)
 		{
 			this._streamCleanUp();
-			this._sendError(error.message);
+			this._sendError(error);
 		}, this);
 
 		this._streamEnd = bindFunction(function()

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -59,6 +59,45 @@
 				},
 			});
 		});
+
+		it('handles errors in beforeFirstChunk', function(done) {
+			var expectedError = new Error('test');
+			Papa.parse(fs.createReadStream(__dirname + '/long-sample.csv', 'utf8'), {
+				beforeFirstChunk: function() {
+					throw expectedError;
+				},
+				error: function(err) {
+					assert.deepEqual(err, expectedError);
+					done();
+				}
+			});
+		});
+
+		it('handles errors in chunk', function(done) {
+			var expectedError = new Error('test');
+			Papa.parse(fs.createReadStream(__dirname + '/long-sample.csv', 'utf8'), {
+				chunk: function() {
+					throw expectedError;
+				},
+				error: function(err) {
+					assert.deepEqual(err, expectedError);
+					done();
+				}
+			});
+		});
+
+		it('handles errors in step', function(done) {
+			var expectedError = new Error('test');
+			Papa.parse(fs.createReadStream(__dirname + '/long-sample.csv', 'utf8'), {
+				step: function() {
+					throw expectedError;
+				},
+				error: function(err) {
+					assert.deepEqual(err, expectedError);
+					done();
+				}
+			});
+		});
 	});
 
 })();


### PR DESCRIPTION
Fixes #472 

There don't seem to be any existing tests that verify the `error` callback, so I added some.