### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _gitignore/
 bower_components/
 node_modules/
+package-lock.json


### PR DESCRIPTION
PapaParse should either commit package-lock.json, or explicitly ignore it. npm still has some bugs that cause a lot of package-lock.json churn, which will be compounded by PapaParse's support for older Node (and npm) versions. So let's go with ignore for now.

jQuery made a similar decision: https://github.com/jquery/jquery/commit/7037facc2243ec24c2b36b770236c05d300aa513