### PR TITLE
Remove support for node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "6"
   - "8"

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ Tests
 
 Papa Parse is under test. Download this repository, run `npm install`, then `npm test` to run the tests.
 
-The continuous integration server runs these tests using Node 0.12. You should ensure your tests pass locally using that version of Node.
-
 Contributing
 ------------
 


### PR DESCRIPTION
Node.js version 0.12 reached end-of-life on 2016-12-31.

See https://github.com/mholt/PapaParse/pull/477#issuecomment-379861967 for context.