### PR TITLE
Ignore yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _gitignore/
 bower_components/
 node_modules/
 package-lock.json
+yarn.lock


### PR DESCRIPTION
This is similar to #476. It allows devs to use yarn to manage their dependencies if they want.