### PR TITLE
Optionally trim whitespace from headers

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -968,11 +968,15 @@
 				return;
 			for (var i = 0; needsHeaderRow() && i < _results.data.length; i++)
 				for (var j = 0; j < _results.data[i].length; j++)
+				{
 					var header = _results.data[i][j];
+
 					if (_config.trimHeaders) {
 						header = header.trim();
 					}
-					_fields.push(_results.data[i][j]);
+
+					_fields.push(header);
+				}
 			_results.data.splice(0, 1);
 		}
 

--- a/papaparse.js
+++ b/papaparse.js
@@ -968,6 +968,10 @@
 				return;
 			for (var i = 0; needsHeaderRow() && i < _results.data.length; i++)
 				for (var j = 0; j < _results.data[i].length; j++)
+					var header = _results.data[i][j];
+					if (_config.trimHeaders) {
+						header = header.trim();
+					}
 					_fields.push(_results.data[i][j]);
 			_results.data.splice(0, 1);
 		}

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -714,6 +714,15 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Header row with whitespace trimmed",
+		input: '  A , B  ,  C  \r\na,b,c',
+		config: { header: true, trimHeaders: true },
+		expected: {
+			data: [{"A": "a", "B": "b", "C": "c"}],
+			errors: []
+		}
+	},
+	{
 		description: "Tab delimiter",
 		input: 'a\tb\tc\r\nd\te\tf',
 		config: { delimiter: "\t" },


### PR DESCRIPTION
Allow developers to trim leading/trailing spaces from headers. Our sample CSV looked like:

"name, duration, due"