### PR TITLE
Add node-style streaming support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,7 @@ module.exports = {
 		"consistent-this": "off",
 		"curly": "off",
 		"default-case": "error",
-		"dot-location": "off",
+		"dot-location": "error",
 		"dot-notation": "error",
 		"eol-last": "error",
 		"eqeqeq": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,7 +42,7 @@ module.exports = {
 		"consistent-this": "off",
 		"curly": "off",
 		"default-case": "error",
-		"dot-location": "error",
+		"dot-location": "off",
 		"dot-notation": "error",
 		"eol-last": "error",
 		"eqeqeq": "error",

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Papa Parse for Node
 
 Papa Parse can parse a [Readable Stream](https://nodejs.org/api/stream.html#stream_readable_streams) instead of a [File](https://www.w3.org/TR/FileAPI/) when used in Node.js environments (in addition to plain strings). In this mode, `encoding` must, if specified, be a Node-supported character encoding. The `Papa.LocalChunkSize`, `Papa.RemoteChunkSize` , `download`, `withCredentials` and `worker` config options are unavailable.
 
+Papa Parse can also parse in a node streaming style which makes `.pipe` available.  Simply pipe the [Readable Stream](https://nodejs.org/api/stream.html#stream_readable_streams) to the stream returned from `Papa.parse(Papa.NODE_STREAM_INPUT, options)`.  The `Papa.LocalChunkSize`, `Papa.RemoteChunkSize` , `download`, `withCredentials`, `worker`, `step`, and `complete` config options are unavailable.  To register a callback with the stream to process data, use the `data` event like so: `stream.on('data', callback)` and to signal the end of stream, use the 'end' event like so: `stream.on('end', callback)`.
+
 Get Started
 -----------
 

--- a/papaparse.js
+++ b/papaparse.js
@@ -58,6 +58,7 @@
 	Papa.BAD_DELIMITERS = ['\r', '\n', '"', Papa.BYTE_ORDER_MARK];
 	Papa.WORKERS_SUPPORTED = !IS_WORKER && !!global.Worker;
 	Papa.SCRIPT_PATH = null;	// Must be set by your code if you use workers and this lib is loaded asynchronously
+	Papa.NODE_STREAM_INPUT = {};
 
 	// Configurable chunk sizes for local and remote files, respectively
 	Papa.LocalChunkSize = 1024 * 1024 * 10;	// 10 MB
@@ -229,7 +230,7 @@
 		}
 
 		var streamer = null;
-		if (_input === null && typeof streamModule !== 'undefined')
+		if (_input === Papa.NODE_STREAM_INPUT)
 		{
 			// create a node Duplex stream for use
 			// with .pipe
@@ -865,7 +866,8 @@
 
 		// streamModule from node must exist
 		// for this to run
-		var duplexStream = new streamModule.Duplex({
+		var stream = require('stream');
+		var duplexStream = new stream.Duplex({
 			readableObjectMode: true,
 			decodeStrings: false,
 			read: function(size) {

--- a/papaparse.js
+++ b/papaparse.js
@@ -850,6 +850,7 @@
 
 	function DuplexStreamStreamer(_config) {
 		var Duplex = require('stream').Duplex;
+		// var self = this;
 		var config = copy(_config);
 		var parseOnWrite = true;
 		var writeStreamHasFinished = false;
@@ -920,30 +921,31 @@
 
 		this._onWrite = function(chunk, encoding, callback)
 		{
+			if (chunk === null) {
+				console.log('final');
+			}
 			this._addToParseQueue(chunk, callback);
 		};
 
-		this._onWriteComplete = function(callback)
+		this._onWriteComplete = function()
 		{
 			writeStreamHasFinished = true;
 			// have to write empty string
 			// so parser knows its done
 			this._addToParseQueue('');
-			callback();
 		};
 
 		this.getStream = function()
 		{
 			return stream;
 		};
-
 		stream = new Duplex({
 			readableObjectMode: true,
 			decodeStrings: false,
 			read: bindFunction(this._onRead, this),
-			write: bindFunction(this._onWrite, this),
-			'final': bindFunction(this._onWriteComplete, this)
+			write: bindFunction(this._onWrite, this)
 		});
+		stream.once('finish', bindFunction(this._onWriteComplete, this));
 	}
 	DuplexStreamStreamer.prototype = Object.create(ChunkStreamer.prototype);
 	DuplexStreamStreamer.prototype.constructor = DuplexStreamStreamer;

--- a/papaparse.js
+++ b/papaparse.js
@@ -850,7 +850,6 @@
 
 	function DuplexStreamStreamer(_config) {
 		var Duplex = require('stream').Duplex;
-		// var self = this;
 		var config = copy(_config);
 		var parseOnWrite = true;
 		var writeStreamHasFinished = false;
@@ -872,6 +871,8 @@
 
 		this._onCsvComplete = function()
 		{
+			// node will finish the read stream when
+			// null is pushed
 			stream.push(null);
 		};
 

--- a/papaparse.js
+++ b/papaparse.js
@@ -873,7 +873,7 @@
 		{
 			stream.push(null);
 		};
-		
+
 		config.step = bindFunction(this._onCsvData, this);
 		config.complete = bindFunction(this._onCsvComplete, this);
 		ChunkStreamer.call(this, config);

--- a/papaparse.js
+++ b/papaparse.js
@@ -890,7 +890,8 @@
 			}
 		};
 
-		this._addToParseQueue = function(chunk, callback) {
+		this._addToParseQueue = function(chunk, callback)
+		{
 			// add to queue so that we can indicate
 			// completion via callback
 			// node will automatically pause the incoming stream

--- a/papaparse.js
+++ b/papaparse.js
@@ -852,7 +852,7 @@
 		var Duplex = require('stream').Duplex;
 		var parseOnWrite = true;
 		var writeStreamHasFinished = false;
-		var writeQueue = [];
+		var parseCallbackQueue = [];
 		var stream = null;
 		var config = copy(_config);
 
@@ -880,11 +880,11 @@
 
 		this._nextChunk = function()
 		{
-			if (writeStreamHasFinished && writeQueue.length === 1) {
+			if (writeStreamHasFinished && parseCallbackQueue.length === 1) {
 				this._finished = true;
 			}
-			if (writeQueue.length) {
-				writeQueue.shift()();
+			if (parseCallbackQueue.length) {
+				parseCallbackQueue.shift()();
 			} else {
 				parseOnWrite = true;
 			}
@@ -896,7 +896,7 @@
 			// node will automatically pause the incoming stream
 			// when too many items have been added without their
 			// callback being invoked
-			writeQueue.push(bindFunction(function() {
+			parseCallbackQueue.push(bindFunction(function() {
 				this.parseChunk(typeof chunk === 'string' ? chunk : chunk.toString(config.encoding));
 				if (isFunction(callback)) {
 					return callback();

--- a/papaparse.js
+++ b/papaparse.js
@@ -17,14 +17,14 @@
 		// Node. Does not work with strict CommonJS, but
 		// only CommonJS-like environments that support module.exports,
 		// like Node.
-		module.exports = factory(require('stream'));
+		module.exports = factory();
 	}
 	else
 	{
 		// Browser globals (root is window)
 		root.Papa = factory();
 	}
-}(this, function(streamModule)
+}(this, function()
 {
 	'use strict';
 
@@ -864,10 +864,10 @@
 			// logic is handled by the Duplex class
 		};
 
-		// streamModule from node must exist
+		// stream module from node must exist
 		// for this to run
-		var stream = require('stream');
-		var duplexStream = new stream.Duplex({
+		var Duplex = require('stream').Duplex;
+		var duplexStream = new Duplex({
 			readableObjectMode: true,
 			decodeStrings: false,
 			read: function(size) {

--- a/papaparse.js
+++ b/papaparse.js
@@ -58,7 +58,7 @@
 	Papa.BAD_DELIMITERS = ['\r', '\n', '"', Papa.BYTE_ORDER_MARK];
 	Papa.WORKERS_SUPPORTED = !IS_WORKER && !!global.Worker;
 	Papa.SCRIPT_PATH = null;	// Must be set by your code if you use workers and this lib is loaded asynchronously
-	Papa.NODE_STREAM_INPUT = {};
+	Papa.NODE_STREAM_INPUT = 1;
 
 	// Configurable chunk sizes for local and remote files, respectively
 	Papa.LocalChunkSize = 1024 * 1024 * 10;	// 10 MB

--- a/papaparse.js
+++ b/papaparse.js
@@ -922,9 +922,6 @@
 
 		this._onWrite = function(chunk, encoding, callback)
 		{
-			if (chunk === null) {
-				console.log('final');
-			}
 			this._addToParseQueue(chunk, callback);
 		};
 

--- a/papaparse.js
+++ b/papaparse.js
@@ -850,11 +850,11 @@
 
 	function DuplexStreamStreamer(_config) {
 		var Duplex = require('stream').Duplex;
+		var config = copy(_config);
 		var parseOnWrite = true;
 		var writeStreamHasFinished = false;
 		var parseCallbackQueue = [];
 		var stream = null;
-		var config = copy(_config);
 
 		this._onCsvData = function(results)
 		{
@@ -873,7 +873,7 @@
 		{
 			stream.push(null);
 		};
-
+		
 		config.step = bindFunction(this._onCsvData, this);
 		config.complete = bindFunction(this._onCsvComplete, this);
 		ChunkStreamer.call(this, config);

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -61,32 +61,32 @@ describe('PapaParse', function() {
 
 	it('piped streaming CSV should be correctly parsed', function(done) {
 		var data = [];
-		fs.createReadStream(__dirname + '/long-sample.csv', 'utf8')
-			.pipe(Papa.parse(Papa.NODE_STREAM_INPUT))
-			.on('data', function(item) {
-				data.push(item);
-			})
-			.on('end', function() {
-				assert.deepEqual(data[0], [
-					'Grant',
-					'Dyer',
-					'Donec.elementum@orciluctuset.example',
-					'2013-11-23T02:30:31-08:00',
-					'2014-05-31T01:06:56-07:00',
-					'Magna Ut Associates',
-					'ljenkins'
-				]);
-				assert.deepEqual(data[7], [
-					'Talon',
-					'Salinas',
-					'posuere.vulputate.lacus@Donecsollicitudin.example',
-					'2015-01-31T09:19:02-08:00',
-					'2014-12-17T04:59:18-08:00',
-					'Aliquam Iaculis Incorporate',
-					'Phasellus@Quisquetincidunt.example'
-				]);
-				done();
-			});
+		var readStream = fs.createReadStream(__dirname + '/long-sample.csv', 'utf8');
+		var csvStream = readStream.pipe(Papa.parse(Papa.NODE_STREAM_INPUT));
+		csvStream.on('data', function(item) {
+			data.push(item);
+		});
+		csvStream.on('end', function() {
+			assert.deepEqual(data[0], [
+				'Grant',
+				'Dyer',
+				'Donec.elementum@orciluctuset.example',
+				'2013-11-23T02:30:31-08:00',
+				'2014-05-31T01:06:56-07:00',
+				'Magna Ut Associates',
+				'ljenkins'
+			]);
+			assert.deepEqual(data[7], [
+				'Talon',
+				'Salinas',
+				'posuere.vulputate.lacus@Donecsollicitudin.example',
+				'2015-01-31T09:19:02-08:00',
+				'2014-12-17T04:59:18-08:00',
+				'Aliquam Iaculis Incorporate',
+				'Phasellus@Quisquetincidunt.example'
+			]);
+			done();
+		});
 	});
 
 	it('should support pausing and resuming on same tick when streaming', function(done) {

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -59,6 +59,36 @@ describe('PapaParse', function() {
 		});
 	});
 
+	it('piped streaming CSV should be correctly parsed', function(done) {
+		var data = [];
+		fs.createReadStream(__dirname + '/long-sample.csv', 'utf8')
+			.pipe(Papa.parse(null))
+			.on('data', function(item) {
+				data.push(item);
+			})
+			.on('end', function() {
+				assert.deepEqual(data[0], [
+					'Grant',
+					'Dyer',
+					'Donec.elementum@orciluctuset.example',
+					'2013-11-23T02:30:31-08:00',
+					'2014-05-31T01:06:56-07:00',
+					'Magna Ut Associates',
+					'ljenkins'
+				]);
+				assert.deepEqual(data[7], [
+					'Talon',
+					'Salinas',
+					'posuere.vulputate.lacus@Donecsollicitudin.example',
+					'2015-01-31T09:19:02-08:00',
+					'2014-12-17T04:59:18-08:00',
+					'Aliquam Iaculis Incorporate',
+					'Phasellus@Quisquetincidunt.example'
+				]);
+				done();
+			});
+	});
+
 	it('should support pausing and resuming on same tick when streaming', function(done) {
 		var rows = [];
 		Papa.parse(fs.createReadStream(__dirname + '/long-sample.csv', 'utf8'), {

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -62,7 +62,7 @@ describe('PapaParse', function() {
 	it('piped streaming CSV should be correctly parsed', function(done) {
 		var data = [];
 		fs.createReadStream(__dirname + '/long-sample.csv', 'utf8')
-			.pipe(Papa.parse(null))
+			.pipe(Papa.parse(Papa.NODE_STREAM_INPUT))
 			.on('data', function(item) {
 				data.push(item);
 			})


### PR DESCRIPTION
This may be a controversial PR and as such I fully expect good feedback and discussion.  That being said, I believe that this is a very useful PR that allows CSV processing on extremely large files to be done much easier.   The node stream API is very good at what it does and so I wanted to take advantage of that.

I had a use case (for which I mentioned in my previous PR) to take a CSV file with 1.6 million entries (145.5MB) and upload each entry to an elasticsearch service.  Before this feature, I had to implement a queue system that would pause the parser when overloaded and resume the parser when empty.  It's not complicated code but it can be tricky to get right.  With this feature in place, I could get rid of all that code and replace it with the following:
```
fs.createReadStream(CSV_FILE_PATH)
    .pipe(Papa.parse(Papa.NODE_STREAM_INPUT, {
      header: true,
      skipEmptyLines: true,
    }))
    .pipe(new stream.Writable({
      objectMode: true,
      highWaterMark: MAX_QUEUE_WORKERS,
      write(doc, encoding, callback) {
        uploadDoc(doc, callback);
      }
    }));
```

Please let me know if there is anything you would me to change or explain.

I also realize that this change would require modifying the documentation.  Please let me know how I can assist in doing that.