### PR TITLE
Drop Node v4 and add v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
   - "9"
+  - "10"
   


### PR DESCRIPTION
v4 reached end of life on 2018-04-30. v10 was released recently.

v9 will reach end of life in June, but we can keep it for now.