### PR TITLE
copy function will copy null primitive correctly now

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1632,7 +1632,7 @@
 	/** Makes a deep copy of an array or object (mostly) */
 	function copy(obj)
 	{
-		if (typeof obj !== 'object')
+		if (typeof obj !== 'object' || obj === null)
 			return obj;
 		var cpy = obj instanceof Array ? [] : {};
 		for (var key in obj)


### PR DESCRIPTION
"typeof null" return "object". the copy() function has been updated to copy null correctly whereas before, null was being converted to {}. this update is important for the transform function PR that I'm going make.