### PR TITLE
Add config option that applies custom function to values

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -203,6 +203,8 @@
 		}
 		_config.dynamicTyping = dynamicTyping;
 
+		_config.transform = isFunction(_config.transform) ? _config.transform : false;
+
 		if (_config.worker && Papa.WORKERS_SUPPORTED)
 		{
 			var w = newWorker();
@@ -976,7 +978,7 @@
 			if (needsHeaderRow())
 				fillHeaderFields();
 
-			return applyHeaderAndDynamicTyping();
+			return applyHeaderAndDynamicTypingAndTransformation();
 		}
 
 		function needsHeaderRow()
@@ -1028,9 +1030,21 @@
 			return value;
 		}
 
-		function applyHeaderAndDynamicTyping()
+		function parseTransform(field, value) {
+			if (_config.transform) {
+				if (_config.transform.length === 1) {
+					return _config.transform(value);
+				} else {
+					return _config.transform(field,value);
+				}
+			} else {
+				return value;
+			}
+		}
+
+		function applyHeaderAndDynamicTypingAndTransformation()
 		{
-			if (!_results || (!_config.header && !_config.dynamicTyping))
+			if (!_results || (!_config.header && !_config.dynamicTyping && !_config.transform))
 				return _results;
 
 			for (var i = 0; i < _results.data.length; i++)
@@ -1046,6 +1060,7 @@
 					if (_config.header)
 						field = j >= _fields.length ? '__parsed_extra' : _fields[j];
 
+					value = parseTransform(field, value);
 					value = parseDynamic(field, value);
 
 					if (field === '__parsed_extra')

--- a/papaparse.js
+++ b/papaparse.js
@@ -1030,14 +1030,6 @@
 			return value;
 		}
 
-		function parseTransform(field, value) {
-			if (_config.transform) {
-				return _config.transform(value,field);
-			} else {
-				return value;
-			}
-		}
-
 		function applyHeaderAndDynamicTypingAndTransformation()
 		{
 			if (!_results || (!_config.header && !_config.dynamicTyping && !_config.transform))
@@ -1056,7 +1048,9 @@
 					if (_config.header)
 						field = j >= _fields.length ? '__parsed_extra' : _fields[j];
 
-					value = parseTransform(field, value);
+					if (_config.transform)
+						value = _config.transform(value,field);
+
 					value = parseDynamic(field, value);
 
 					if (field === '__parsed_extra')

--- a/papaparse.js
+++ b/papaparse.js
@@ -1032,11 +1032,7 @@
 
 		function parseTransform(field, value) {
 			if (_config.transform) {
-				if (_config.transform.length === 1) {
-					return _config.transform(value);
-				} else {
-					return _config.transform(field,value);
-				}
+				return _config.transform(value,field);
 			} else {
 				return value;
 			}

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -873,6 +873,66 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Custom transform function converts all true and false strings to booleans regardless of case",
+		input: '"true","false","T","F"\r\n"TRUE","FALSE","True","False"',
+		config: {
+			transform: function(value) {
+				if(typeof value === "string" && value.toLowerCase() === "true") return true;
+				if(typeof value === "string" && value.toLowerCase() === "false") return false;
+				return value;
+			}
+		},
+		expected: {
+			data: [[true,false,"T","F"], [true, false, true, false]],
+			errors: []
+		}
+	},
+	{
+		description: "Custom transform function converts leading zero strings to number and empty strings to NULL",
+		input: '001,002,003\r\n,null,undefined',
+		config: {
+			transform: function(value) {
+				if ((/^\s*-?(\d*\.?\d+|\d+\.?\d*)(e[-+]?\d+)?\s*$/i).test(value)) {
+					return Number.parseFloat(value);
+				} else if (value === "") {
+					return null;
+				}
+				return value;
+			}
+		},
+		expected: {
+			data: [[1,2,3], [null,"null","undefined"]],
+			errors: []
+		}
+	},
+	{
+		description: "Custom transform function uses cache to determine whether to act on column",
+		input: 'A,B,C\r\n1,2,3\r\n4,5,6',
+		config: {
+			transform: function(field,value) {
+				if (!this.transformCache) {
+					this.transformCache = {};
+				} else if (this.transformCache[field] === true) {
+					return value + ".0";
+				} else if (this.transformCache[field] === false) {
+					return value;
+				}
+
+				if (field > 0) {
+					this.transformCache[field] = true;
+					return value + ".0";
+				} else {
+					this.transformCache[field] = false;
+					return value;
+				}
+			}
+		},
+		expected: {
+			data: [["A","B.0","C.0"], ["1","2.0","3.0"], ["4","5.0","6.0"]],
+			errors: []
+		}
+	},
+	{
 		description: "Blank line at beginning",
 		input: '\r\na,b,c\r\nd,e,f',
 		config: { newline: '\r\n' },

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -873,62 +873,15 @@ var PARSE_TESTS = [
 		}
 	},
 	{
-		description: "Custom transform function converts all true and false strings to booleans regardless of case",
-		input: '"true","false","T","F"\r\n"TRUE","FALSE","True","False"',
+		description: "Custom transform function is applied to values",
+		input: 'A,B,C\r\nd,e,f',
 		config: {
 			transform: function(value) {
-				if(typeof value === "string" && value.toLowerCase() === "true") return true;
-				if(typeof value === "string" && value.toLowerCase() === "false") return false;
-				return value;
+				return value.toLowerCase();
 			}
 		},
 		expected: {
-			data: [[true,false,"T","F"], [true, false, true, false]],
-			errors: []
-		}
-	},
-	{
-		description: "Custom transform function converts leading zero strings to number and empty strings to NULL",
-		input: '001,002,003\r\n,null,undefined',
-		config: {
-			transform: function(value) {
-				if ((/^\s*-?(\d*\.?\d+|\d+\.?\d*)(e[-+]?\d+)?\s*$/i).test(value)) {
-					return Number.parseFloat(value);
-				} else if (value === "") {
-					return null;
-				}
-				return value;
-			}
-		},
-		expected: {
-			data: [[1,2,3], [null,"null","undefined"]],
-			errors: []
-		}
-	},
-	{
-		description: "Custom transform function uses cache to determine whether to act on column",
-		input: 'A,B,C\r\n1,2,3\r\n4,5,6',
-		config: {
-			transform: function(field,value) {
-				if (!this.transformCache) {
-					this.transformCache = {};
-				} else if (this.transformCache[field] === true) {
-					return value + ".0";
-				} else if (this.transformCache[field] === false) {
-					return value;
-				}
-
-				if (field > 0) {
-					this.transformCache[field] = true;
-					return value + ".0";
-				} else {
-					this.transformCache[field] = false;
-					return value;
-				}
-			}
-		},
-		expected: {
-			data: [["A","B.0","C.0"], ["1","2.0","3.0"], ["4","5.0","6.0"]],
+			data: [["a","b","c"], ["d","e","f"]],
 			errors: []
 		}
 	},


### PR DESCRIPTION
This PR addresses issue: "dynamicTyping should use JSON.parse and config should allow custom processing #487"

The config can now take the key 'transform' with a function value. That function can apply transformations to the values in a CSV.

This allows the use of the JSON.parse() functionality I discussed without affecting the current dynamicTyping option.