### PR TITLE
Allow multi-characters delimiter at serialization.

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -271,7 +271,7 @@
 		/** whether to write headers */
 		var _writeHeader = true;
 
-		/** delimiting character */
+		/** delimiting character(s) */
 		var _delimiter = ',';
 
 		/** newline character(s) */

--- a/papaparse.js
+++ b/papaparse.js
@@ -326,9 +326,10 @@
 				return;
 
 			if (typeof _config.delimiter === 'string'
-				&& _config.delimiter.length === 1
-				&& Papa.BAD_DELIMITERS.indexOf(_config.delimiter) === -1)
+                && !Papa.BAD_DELIMITERS.filter(function(value) { return _config.delimiter.includes(value); }).length)
 			{
+				// We have a string as config and it does not contains any
+				// of the invalid delimiters.
 				_delimiter = _config.delimiter;
 			}
 

--- a/papaparse.js
+++ b/papaparse.js
@@ -328,8 +328,6 @@
 			if (typeof _config.delimiter === 'string'
                 && !Papa.BAD_DELIMITERS.filter(function(value) { return _config.delimiter.indexOf(value) !== -1; }).length)
 			{
-				// We have a string as config and it does not contains any
-				// of the invalid delimiters.
 				_delimiter = _config.delimiter;
 			}
 

--- a/papaparse.js
+++ b/papaparse.js
@@ -326,7 +326,7 @@
 				return;
 
 			if (typeof _config.delimiter === 'string'
-                && !Papa.BAD_DELIMITERS.filter(function(value) { return _config.delimiter.includes(value); }).length)
+                && !Papa.BAD_DELIMITERS.filter(function(value) { return _config.delimiter.indexOf(value) !== -1; }).length)
 			{
 				// We have a string as config and it does not contains any
 				// of the invalid delimiters.

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1397,6 +1397,12 @@ var UNPARSE_TESTS = [
 		expected: 'a' + RECORD_SEP + 'b' + RECORD_SEP + 'c\r\nd' + RECORD_SEP + 'e' + RECORD_SEP + 'f'
 	},
 	{
+		description: "Custom delimiter (Multi-character)",
+		input: [['A', 'b', 'c'], ['d', 'e', 'f']],
+		config: { delimiter: ', ' },
+		expected: 'A, b, c\r\nd, e, f'
+	},
+	{
 		description: "Bad delimiter (\\n)",
 		notes: "Should default to comma",
 		input: [['a', 'b', 'c'], ['d', 'e', 'f']],

--- a/tests/test.js
+++ b/tests/test.js
@@ -8,9 +8,8 @@ var server = connect().use(serveStatic(path.join(__dirname, '/..'))).listen(8071
 	if (process.argv.indexOf('--phantomjs') !== -1) {
 		childProcess.spawn('node_modules/.bin/mocha-phantomjs', ['http://localhost:8071/tests/tests.html'], {
 			stdio: 'inherit'
-		}).on('exit', function(code) {
+		}).on('exit', function() {
 			server.close();
-			process.exit(code);  // eslint-disable-line no-process-exit
 		});
 
 	} else {

--- a/tests/test.js
+++ b/tests/test.js
@@ -8,8 +8,9 @@ var server = connect().use(serveStatic(path.join(__dirname, '/..'))).listen(8071
 	if (process.argv.indexOf('--phantomjs') !== -1) {
 		childProcess.spawn('node_modules/.bin/mocha-phantomjs', ['http://localhost:8071/tests/tests.html'], {
 			stdio: 'inherit'
-		}).on('exit', function() {
+		}).on('exit', function(code) {
 			server.close();
+			process.exit(code)
 		});
 
 	} else {

--- a/tests/test.js
+++ b/tests/test.js
@@ -10,7 +10,7 @@ var server = connect().use(serveStatic(path.join(__dirname, '/..'))).listen(8071
 			stdio: 'inherit'
 		}).on('exit', function(code) {
 			server.close();
-			process.exit(code)
+			process.exit(code);  // eslint-disable-line no-process-exit
 		});
 
 	} else {


### PR DESCRIPTION
Scope
=====

This updates the serialization code to allow multi-character delimiters.

I want to present the values in a more human readable format with `, ` as delimiter so that the lines will be `1, 2, 3` instead of `1,2,3`


Changes
========

Update the validation to not enforce single characters, but to still filter against invalid characters.

In this way there is no regression and all previous tests pass.

I added a new test to showcase this functionality

As a drive-by fix, I have updated the phantomjs test runner to propagate the exit code
as it was always exiting with 0 even on errors see https://travis-ci.org/mholt/PapaParse/jobs/389825011#L1418

----------

Once this is accepted the documentation needs to be updated at https://github.com/mholt/PapaParse/blob/gh-pages/docs.html#L256

to inform that it accepts multiple characters

Thanks for the nice library.

I hope you can accept this change. Let me know if you want anything done in another way.

