### PR TITLE
Strip spaces from quoted values.

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1393,10 +1393,19 @@
 			var nextNewline = input.indexOf(newline, cursor);
 			var quoteCharRegex = new RegExp(escapeChar.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&') + quoteChar, 'g');
 			var quoteSearch;
+			var trailingSpacesRegex = new RegExp('^[ ]+(".*)');
+			var trailingSpacesSearch;
 
 			// Parser loop
 			for (;;)
 			{
+				trailingSpacesSearch = input.substring(cursor).match(trailingSpacesRegex);
+				if (trailingSpacesSearch) {
+					// We have a quoted value with trailing space(s), so we
+					// ignore the spaces.
+					cursor += 1;
+					continue;
+				}
 				// Field has opening quote
 				if (input[cursor] === quoteChar)
 				{

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -167,10 +167,26 @@ var CORE_PARSER_TESTS = [
 	},
 	{
 		description: "Quoted field with whitespace around quotes",
-		input: 'A, "B" ,C',
-		notes: "The quotes must be immediately adjacent to the delimiter to indicate a quoted field",
+		input: 'A,  "B"  ,"C"  ,  "D",E "F',
+		notes: "The quotes must be immediately adjacent to the delimiter to indicate a quoted field, but there are leading or trailing spaces they are ignored",
 		expected: {
-			data: [['A', ' "B" ', 'C']],
+			data: [['A', 'B', 'C', 'D', 'E "F']],
+			errors: []
+		}
+	},
+	{
+		description: "Quoted fields with comma",
+		input: '"A","b,C"\nD"E,f',
+		expected: {
+			data: [['A', 'b,C'],['D"E', 'f']],
+			errors: []
+		}
+	},
+	{
+		description: "Quoted fields with comma and whitespace before and after quotes",
+		input: '"A" ,   "b , C"   \n  D"E ,  f ',
+		expected: {
+			data: [['A', 'b , C'],['  D"E ', '  f ']],
 			errors: []
 		}
 	},

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -167,10 +167,10 @@ var CORE_PARSER_TESTS = [
 	},
 	{
 		description: "Quoted field with whitespace around quotes",
-		input: 'A,  "B"  ,"C"  ,  "D",E "F',
+		input: 'A,  "B"  ,"C"  ,  "D",E "F," ""G"" ",H',
 		notes: "The quotes must be immediately adjacent to the delimiter to indicate a quoted field, but there are leading or trailing spaces they are ignored",
 		expected: {
-			data: [['A', 'B', 'C', 'D', 'E "F']],
+			data: [['A', 'B', 'C', 'D', 'E "F',' "G" ', 'H']],
 			errors: []
 		}
 	},


### PR DESCRIPTION
Scope
=====

When you have a value which is enclosed in quotes, the spaces outside of the quotes are stripped.

If they are not stripped, papaparse, as of master branch breaks.

But even if it does not break, if you have spaces it return a value like `<space>"B"<space>` (not sure how to add spaces in mardown.
With this, is hard to tell whever that value came from `, "B" ,` or from `," ""B"" ",`

Changes
=======

I have updated an existing test so this introduced a backward incompatibility...but I hope the previous behaviour, even if explicitly documented by a test can be considered a bug.

For the part in which spaces are ignored, I just went with a simple `+1` instead of trying to do anothe search and have a smart cursor positioning

Let me know if you find this useful or you want something changed.
I hope this can be done without adding an extra configuration option.

Thanks!