### PR TITLE
Fix exit code for phantomjs test runner.

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -8,8 +8,9 @@ var server = connect().use(serveStatic(path.join(__dirname, '/..'))).listen(8071
 	if (process.argv.indexOf('--phantomjs') !== -1) {
 		childProcess.spawn('node_modules/.bin/mocha-phantomjs', ['http://localhost:8071/tests/tests.html'], {
 			stdio: 'inherit'
-		}).on('exit', function() {
+		}).on('exit', function(code) {
 			server.close();
+			process.exit(code);  // eslint-disable-line no-process-exit
 		});
 
 	} else {


### PR DESCRIPTION
Scope
=====

This fix a bug in which the exit code from phantom test runner is ignored.

You will see the output with error, but the exit code is 0.

Changes
=======

Just end the process with the same exit code as the forked phantom process.

I have ignored the jslint error and not used an exception as I think that this should be a clear exit point.


How to test
=========

Write some ES6 code, for example using then `=>` function.
Run `$ node run test-phantomjs`
Then run `$ echo $?`

You should see that if all tests pass the output is 0 while a non-zero is used for any error case.