### PR TITLE
Add config option to convert headers to lowercase

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1113,6 +1113,10 @@
 						header = header.trim();
 					}
 
+					if (_config.lowercaseHeaders) {
+						header = header.toLowerCase();
+					}
+
 					_fields.push(header);
 				}
 			_results.data.splice(0, 1);

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -734,6 +734,15 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Header rows are lowercase when lowercaseHeader is set",
+		input: 'A,b\r\na,b',
+		config: { header: true, lowercaseHeaders: true },
+		expected: {
+			data: [{"a": "a", "b": "b"}],
+			errors: []
+		}
+	},
+	{
 		description: "Line ends with quoted field, first field of next line is empty using headers",
 		input: 'a,b,"c"\r\nd,e,"f"\r\n,"h","i"\r\n,"k","l"',
 		config: {


### PR DESCRIPTION
Allows you to convert headers to lowercase which is particularly useful when parsing CSV files prone to human errors.