### PR TITLE
Fix linebreak problem in headers

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1257,7 +1257,7 @@
 		{
 			input = input.substr(0, 1024 * 1024);	// max length 1 MB
 			// Replace all the text inside quotes
-			var re = new RegExp(quoteChar + '([^]*?)' + quoteChar, 'gm');
+			var re = new RegExp(escapeRegExp(quoteChar) + '([^]*?)' + escapeRegExp(quoteChar), 'gm');
 			input = input.replace(re, '');
 
 			var r = input.split('\r');
@@ -1290,9 +1290,10 @@
 		}
 	}
 
-
-
-
+	/** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions */
+	function escapeRegExp(string) {
+		return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+	}
 
 	/** The core parser implements speedy and correct CSV parsing */
 	function Parser(config)

--- a/papaparse.js
+++ b/papaparse.js
@@ -1008,7 +1008,7 @@
 		 */
 		this.parse = function(input, baseIndex, ignoreLastRow)
 		{
-            var quoteChar = _config.quoteChar || '"';
+			var quoteChar = _config.quoteChar || '"';
 			if (!_config.newline)
 				_config.newline = guessLineEndings(input, quoteChar);
 
@@ -1258,7 +1258,7 @@
 			input = input.substr(0, 1024 * 1024);	// max length 1 MB
 			// Replace all the text inside quotes
 			var re = new RegExp(quoteChar + '(.*?)' + quoteChar, 'gm');
-			input = input.replace(re, '')
+			input = input.replace(re, '');
 
 			var r = input.split('\r');
 

--- a/papaparse.js
+++ b/papaparse.js
@@ -1008,8 +1008,9 @@
 		 */
 		this.parse = function(input, baseIndex, ignoreLastRow)
 		{
+            var quoteChar = _config.quoteChar || '"';
 			if (!_config.newline)
-				_config.newline = guessLineEndings(input);
+				_config.newline = guessLineEndings(input, quoteChar);
 
 			_delimiterError = false;
 			if (!_config.delimiter)
@@ -1252,9 +1253,12 @@
 			};
 		}
 
-		function guessLineEndings(input)
+		function guessLineEndings(input, quoteChar)
 		{
 			input = input.substr(0, 1024 * 1024);	// max length 1 MB
+			// Replace all the text inside quotes
+			var re = new RegExp(quoteChar + '(.*?)' + quoteChar, 'gm');
+			input = input.replace(re, '')
 
 			var r = input.split('\r');
 

--- a/papaparse.js
+++ b/papaparse.js
@@ -1257,7 +1257,7 @@
 		{
 			input = input.substr(0, 1024 * 1024);	// max length 1 MB
 			// Replace all the text inside quotes
-			var re = new RegExp(quoteChar + '(.*?)' + quoteChar, 'gm');
+			var re = new RegExp(quoteChar + '([^]*?)' + quoteChar, 'gm');
 			input = input.replace(re, '');
 
 			var r = input.split('\r');

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1208,6 +1208,15 @@ var PARSE_TESTS = [
 			data: [{'a': 'c', 'b': 'd'}],
 			errors: []
 		}
+	},
+	{
+		description: "Mixture of newlines",
+		input: '"a\r\na","b"\n"c","d"\n\n',
+		config: { skipEmptyLines: true },
+		expected: {
+			data: [['a\r\na', 'b'], ['c', 'd']],
+			errors: []
+		}
 	}
 ];
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1233,6 +1233,7 @@ describe('Parse Tests', function() {
 	function generateTest(test) {
 		(test.disabled ? it.skip : it)(test.description, function() {
 			var actual = Papa.parse(test.input, test.config);
+			test.expected.meta && assert.deepEqual(actual.meta, test.expected.meta);
 			assert.deepEqual(JSON.stringify(actual.errors), JSON.stringify(test.expected.errors));
 			assert.deepEqual(actual.data, test.expected.data);
 		});

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1226,6 +1226,86 @@ var PARSE_TESTS = [
 			data: [['a\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],
 			errors: []
 		}
+	},
+	{
+		description: "Using \\r\\n endings uses \\r\\n linebreak",
+		input: 'a,b\r\nc,d\r\ne,f\r\ng,h\r\ni,j',
+		config: {},
+		expected: {
+			data: [['a', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],
+			errors: [],
+			meta: {
+				linebreak: '\r\n',
+				delimiter: ',',
+				cursor: 23,
+				aborted: false,
+				truncated: false
+			}
+		}
+	},
+	{
+		description: "Using \\n endings uses \\n linebreak",
+		input: 'a,b\nc,d\ne,f\ng,h\ni,j',
+		config: {},
+		expected: {
+			data: [['a', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],
+			errors: [],
+			meta: {
+				linebreak: '\n',
+				delimiter: ',',
+				cursor: 19,
+				aborted: false,
+				truncated: false
+			}
+		}
+	},
+	{
+		description: "Using \\r\\n endings with \\r\\n in header field uses \\r\\n linebreak",
+		input: '"a\r\na",b\r\nc,d\r\ne,f\r\ng,h\r\ni,j',
+		config: {},
+		expected: {
+			data: [['a\r\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],
+			errors: [],
+			meta: {
+				linebreak: '\r\n',
+				delimiter: ',',
+				cursor: 28,
+				aborted: false,
+				truncated: false
+			}
+		}
+	},
+	{
+		description: "Using \\r\\n endings with \\n in header field uses \\r\\n linebreak",
+		input: '"a\na",b\r\nc,d\r\ne,f\r\ng,h\r\ni,j',
+		config: {},
+		expected: {
+			data: [['a\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],
+			errors: [],
+			meta: {
+				linebreak: '\r\n',
+				delimiter: ',',
+				cursor: 27,
+				aborted: false,
+				truncated: false
+			}
+		}
+	},
+	{
+		description: "Using \\n endings with \\r\\n in header field uses \\n linebreak",
+		input: '"a\r\na",b\nc,d\ne,f\ng,h\ni,j',
+		config: {},
+		expected: {
+			data: [['a\r\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],
+			errors: [],
+			meta: {
+				linebreak: '\n',
+				delimiter: ',',
+				cursor: 24,
+				aborted: false,
+				truncated: false
+			}
+		}
 	}
 ];
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1292,6 +1292,22 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Using \\r\\n endings with \\n in header field with skip empty lines uses \\r\\n linebreak",
+		input: '"a\na",b\r\nc,d\r\ne,f\r\ng,h\r\ni,j\r\n',
+		config: {skipEmptyLines: true},
+		expected: {
+			data: [['a\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],
+			errors: [],
+			meta: {
+				linebreak: '\r\n',
+				delimiter: ',',
+				cursor: 29,
+				aborted: false,
+				truncated: false
+			}
+		}
+	},
+	{
 		description: "Using \\n endings with \\r\\n in header field uses \\n linebreak",
 		input: '"a\r\na",b\nc,d\ne,f\ng,h\ni,j',
 		config: {},

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1211,7 +1211,7 @@ var PARSE_TESTS = [
 	},
 	{
 		description: "Carriage return in header inside quotes, with line feed endings",
-		input: '"a\r\na","b"\n"c","d"\n"e","f"\n"g","h"\n"i","j"\n',
+		input: '"a\r\na","b"\n"c","d"\n"e","f"\n"g","h"\n"i","j"',
 		config: {},
 		expected: {
 			data: [['a\r\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],
@@ -1220,7 +1220,7 @@ var PARSE_TESTS = [
 	},
 	{
 		description: "Line feed in header inside quotes, with carriage return + line feed endings",
-		input: '"a\na","b"\r\n"c","d"\r\n"e","f"\r\n"g","h"\r\n"i","j"\r\n',
+		input: '"a\na","b"\r\n"c","d"\r\n"e","f"\r\n"g","h"\r\n"i","j"',
 		config: {},
 		expected: {
 			data: [['a\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1210,11 +1210,11 @@ var PARSE_TESTS = [
 		}
 	},
 	{
-		description: "Mixture of newlines",
-		input: '"a\r\na","b"\n"c","d"\n\n',
+		description: "Carriage return in header inside quotes, with line feed endings",
+		input: '"a\r\na","b"\n"c","d"\n"e","f"\n,"g","h"\n"i","j"\n',
 		config: { skipEmptyLines: true },
 		expected: {
-			data: [['a\r\na', 'b'], ['c', 'd']],
+			data: [['a\r\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h']['i', 'j']],
 			errors: []
 		}
 	}

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1329,7 +1329,10 @@ describe('Parse Tests', function() {
 	function generateTest(test) {
 		(test.disabled ? it.skip : it)(test.description, function() {
 			var actual = Papa.parse(test.input, test.config);
-			test.expected.meta && assert.deepEqual(actual.meta, test.expected.meta);
+			// allows for testing the meta object if present in the test
+			if (test.expected.meta) {
+				assert.deepEqual(actual.meta, test.expected.meta);
+			}
 			assert.deepEqual(JSON.stringify(actual.errors), JSON.stringify(test.expected.errors));
 			assert.deepEqual(actual.data, test.expected.data);
 		});

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1214,7 +1214,7 @@ var PARSE_TESTS = [
 		input: '"a\r\na","b"\n"c","d"\n"e","f"\n"g","h"\n"i","j"\n',
 		config: {},
 		expected: {
-			data: [['a\r\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h']['i', 'j']],
+			data: [['a\r\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],
 			errors: []
 		}
 	}

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1322,6 +1322,22 @@ var PARSE_TESTS = [
 				truncated: false
 			}
 		}
+	},
+	{
+		description: "Using reserved regex characters as quote characters",
+		input: '.a\na.,b\r\nc,d\r\ne,f\r\ng,h\r\ni,j',
+		config: { quoteChar: '.' },
+		expected: {
+			data: [['a\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],
+			errors: [],
+			meta: {
+				linebreak: '\r\n',
+				delimiter: ',',
+				cursor: 27,
+				aborted: false,
+				truncated: false
+			}
+		}
 	}
 ];
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1217,6 +1217,15 @@ var PARSE_TESTS = [
 			data: [['a\r\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],
 			errors: []
 		}
+	},
+	{
+		description: "Line feed in header inside quotes, with carriage return + line feed endings",
+		input: '"a\na","b"\r\n"c","d"\r\n"e","f"\r\n"g","h"\r\n"i","j"\r\n',
+		config: {},
+		expected: {
+			data: [['a\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h'], ['i', 'j']],
+			errors: []
+		}
 	}
 ];
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1211,8 +1211,8 @@ var PARSE_TESTS = [
 	},
 	{
 		description: "Carriage return in header inside quotes, with line feed endings",
-		input: '"a\r\na","b"\n"c","d"\n"e","f"\n,"g","h"\n"i","j"\n',
-		config: { skipEmptyLines: true },
+		input: '"a\r\na","b"\n"c","d"\n"e","f"\n"g","h"\n"i","j"\n',
+		config: {},
 		expected: {
 			data: [['a\r\na', 'b'], ['c', 'd'], ['e', 'f'], ['g', 'h']['i', 'j']],
 			errors: []


### PR DESCRIPTION
Supersedes https://github.com/mholt/PapaParse/pull/449 with improved regex and added tests.
Resolves #252 
Resolves #457
Resolves #535 

Test-driven correction for bugs regarding linebreaks in quoted header fields that are not the same time as the linebreaks between rows. I was able to mostly fix it using an improved regex (using `[^]*?` instead of `.*?` for replacing across newlines).