### PR TITLE
New feature: Option to skip lines with no content

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -90,10 +90,6 @@
 						<dfn>By default, empty lines are parsed; check to skip.</dfn>
 					</label>
 
-					<label>
-						<input type="checkbox" id="skipNoContentLines"> Skip lines without content
-						<dfn>By default, lines that only have delimiters, quotes, and whitespace are still parsed; check to skip.</dfn>
-					</label>
 				</div>
 
 				<div class="grid-75 grid-parent">

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -89,6 +89,11 @@
 						<input type="checkbox" id="skipEmptyLines"> Skip empty lines
 						<dfn>By default, empty lines are parsed; check to skip.</dfn>
 					</label>
+
+					<label>
+						<input type="checkbox" id="skipNoContentLines"> Skip lines without content
+						<dfn>By default, lines that only have delimiters, quotes, and whitespace are still parsed; check to skip.</dfn>
+					</label>
 				</div>
 
 				<div class="grid-75 grid-parent">

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -351,7 +351,6 @@ var csv = Papa.unparse({
 	error: undefined,
 	download: false,
 	skipEmptyLines: false,
-	skipNoContentLines: false,
 	chunk: undefined,
 	fastMode: undefined,
 	beforeFirstChunk: undefined,
@@ -506,15 +505,7 @@ var csv = Papa.unparse({
 									<code>skipEmptyLines</code>
 								</td>
 								<td>
-									If true, lines that are completely empty will be skipped. An empty line is defined to be one which evaluates to empty string.
-								</td>
-							</tr>
-							<tr>
-								<td>
-									<code>skipNoContentLines</code>
-								</td>
-								<td>
-									If true, lines that don't have any content will be skipped. Lacking content is defined as having only delimiters, quotes, and whitespace. <code>skipNoContentLines</code> can be set alongside <code>skipEmptyLines</code> or instead of <code>skipEmptyLines</code> and retain the same functionality.
+									If true, lines that are completely empty (those which evaluate to an empty string) will be skipped. If set to <code>'strict'</code>, lines that don't have any content (those which have only delimiters, quotes, and whitespace) will also be skipped.
 								</td>
 							</tr>
 							<tr>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -505,7 +505,7 @@ var csv = Papa.unparse({
 									<code>skipEmptyLines</code>
 								</td>
 								<td>
-									If true, lines that are completely empty (those which evaluate to an empty string) will be skipped. If set to <code>'strict'</code>, lines that don't have any content (those which have only delimiters, quotes, and whitespace) will also be skipped.
+									If true, lines that are completely empty (those which evaluate to an empty string) will be skipped. If set to <code>'greedy'</code>, lines that don't have any content (those which have only delimiters, quotes, and whitespace) will also be skipped.
 								</td>
 							</tr>
 							<tr>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -505,7 +505,7 @@ var csv = Papa.unparse({
 									<code>skipEmptyLines</code>
 								</td>
 								<td>
-									If true, lines that are completely empty (those which evaluate to an empty string) will be skipped. If set to <code>'greedy'</code>, lines that don't have any content (those which have only delimiters, quotes, and whitespace) will also be skipped.
+									If true, lines that are completely empty (those which evaluate to an empty string) will be skipped. If set to <code>'greedy'</code>, lines that don't have any content (those which have only whitespace after parsing) will also be skipped.
 								</td>
 							</tr>
 							<tr>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -351,6 +351,7 @@ var csv = Papa.unparse({
 	error: undefined,
 	download: false,
 	skipEmptyLines: false,
+	skipNoContentLines: false,
 	chunk: undefined,
 	fastMode: undefined,
 	beforeFirstChunk: undefined,
@@ -506,6 +507,14 @@ var csv = Papa.unparse({
 								</td>
 								<td>
 									If true, lines that are completely empty will be skipped. An empty line is defined to be one which evaluates to empty string.
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>skipNoContentLines</code>
+								</td>
+								<td>
+									If true, lines that don't have any content will be skipped. Lacking content is defined as having only delimiters, quotes, and whitespace. <code>skipNoContentLines</code> can be set alongside <code>skipEmptyLines</code> or instead of <code>skipEmptyLines</code> and retain the same functionality.
 								</td>
 							</tr>
 							<tr>

--- a/docs/resources/js/demo.js
+++ b/docs/resources/js/demo.js
@@ -191,7 +191,6 @@ function buildConfig()
 		header: $('#header').prop('checked'),
 		dynamicTyping: $('#dynamicTyping').prop('checked'),
 		skipEmptyLines: $('#skipEmptyLines').prop('checked'),
-		skipNoContentLines: $('#skipNoContentLines').prop('checked'),
 		preview: parseInt($('#preview').val() || 0),
 		step: $('#stream').prop('checked') ? stepFn : undefined,
 		encoding: $('#encoding').val(),

--- a/docs/resources/js/demo.js
+++ b/docs/resources/js/demo.js
@@ -191,6 +191,7 @@ function buildConfig()
 		header: $('#header').prop('checked'),
 		dynamicTyping: $('#dynamicTyping').prop('checked'),
 		skipEmptyLines: $('#skipEmptyLines').prop('checked'),
+		skipNoContentLines: $('#skipNoContentLines').prop('checked'),
 		preview: parseInt($('#preview').val() || 0),
 		step: $('#stream').prop('checked') ? stepFn : undefined,
 		encoding: $('#encoding').val(),

--- a/papaparse.js
+++ b/papaparse.js
@@ -1015,7 +1015,7 @@
 			_delimiterError = false;
 			if (!_config.delimiter)
 			{
-				var delimGuess = guessDelimiter(input, _config.newline, (_config.skipEmptyLines || _config.skipNoContentLines), _config.comments);
+				var delimGuess = guessDelimiter(input, _config.newline, _config.skipEmptyLines, _config.comments);
 				if (delimGuess.successful)
 					_config.delimiter = delimGuess.bestDelimiter;
 				else
@@ -1077,7 +1077,7 @@
 
 		function testEmptyLine(s, d) {
 			var q = _config.quoteChar || '"';
-			var r = _config.skipNoContentLines ? new RegExp('^[' + escapeRegExp(d) + escapeRegExp(q) + '\\s]*$') : new RegExp('^$');
+			var r = _config.skipEmptyLines === 'strict' ? new RegExp('^[' + escapeRegExp(d) + escapeRegExp(q) + '\\s]*$') : new RegExp('^$');
 			for (var i = 0; i < s.length; i++)
 				if (r.test(s[i]))
 					return true;
@@ -1092,7 +1092,7 @@
 				_delimiterError = false;
 			}
 
-			if (_config.skipEmptyLines || _config.skipNoContentLines)
+			if (_config.skipEmptyLines)
 			{
 				for (var i = 0; i < _results.data.length; i++)
 					if (testEmptyLine(_results.data[i], _config.delimiter))

--- a/papaparse.js
+++ b/papaparse.js
@@ -1075,13 +1075,8 @@
 			_input = '';
 		};
 
-		function testEmptyLine(s, d) {
-			var q = _config.quoteChar || '"';
-			var r = _config.skipEmptyLines === 'greedy' ? new RegExp('^[' + escapeRegExp(d) + escapeRegExp(q) + '\\s]*$') : new RegExp('^$');
-			for (var i = 0; i < s.length; i++)
-				if (r.test(s[i]))
-					return true;
-			return false;
+		function testEmptyLine(s) {
+			return _config.skipEmptyLines === 'greedy' ? s.join('').trim() === '' : s.length === 1 && s[0].length === 0;
 		}
 
 		function processResults()

--- a/papaparse.js
+++ b/papaparse.js
@@ -1090,7 +1090,7 @@
 			if (_config.skipEmptyLines)
 			{
 				for (var i = 0; i < _results.data.length; i++)
-					if (testEmptyLine(_results.data[i], _config.delimiter))
+					if (testEmptyLine(_results.data[i]))
 						_results.data.splice(i--, 1);
 			}
 
@@ -1219,7 +1219,7 @@
 
 				for (var j = 0; j < preview.data.length; j++)
 				{
-					if (skipEmptyLines && testEmptyLine(preview.data[j], delim))
+					if (skipEmptyLines && testEmptyLine(preview.data[j]))
 					{
 						emptyLinesCount++;
 						continue;

--- a/papaparse.js
+++ b/papaparse.js
@@ -1077,7 +1077,7 @@
 
 		function testEmptyLine(s, d) {
 			var q = _config.quoteChar || '"';
-			var r = _config.skipEmptyLines === 'strict' ? new RegExp('^[' + escapeRegExp(d) + escapeRegExp(q) + '\\s]*$') : new RegExp('^$');
+			var r = _config.skipEmptyLines === 'greedy' ? new RegExp('^[' + escapeRegExp(d) + escapeRegExp(q) + '\\s]*$') : new RegExp('^$');
 			for (var i = 0; i < s.length; i++)
 				if (r.test(s[i]))
 					return true;

--- a/papaparse.js
+++ b/papaparse.js
@@ -1015,7 +1015,7 @@
 			_delimiterError = false;
 			if (!_config.delimiter)
 			{
-				var delimGuess = guessDelimiter(input, _config.newline, _config.skipEmptyLines, _config.comments);
+				var delimGuess = guessDelimiter(input, _config.newline, (_config.skipEmptyLines || _config.skipNoContentLines), _config.comments);
 				if (delimGuess.successful)
 					_config.delimiter = delimGuess.bestDelimiter;
 				else
@@ -1075,6 +1075,15 @@
 			_input = '';
 		};
 
+		function testEmptyLine(s, d) {
+			var q = _config.quoteChar || '"';
+			var r = _config.skipNoContentLines ? new RegExp('^[' + d + q + '\\s]*$') : new RegExp('^$');
+			for (var i = 0; i < s.length; i++)
+				if (r.test(s[i]))
+					return true;
+			return false;
+		}
+
 		function processResults()
 		{
 			if (_results && _delimiterError)
@@ -1083,10 +1092,10 @@
 				_delimiterError = false;
 			}
 
-			if (_config.skipEmptyLines)
+			if (_config.skipEmptyLines || _config.skipNoContentLines)
 			{
 				for (var i = 0; i < _results.data.length; i++)
-					if (_results.data[i].length === 1 && _results.data[i][0] === '')
+					if (testEmptyLine(_results.data[i], _config.delimiter))
 						_results.data.splice(i--, 1);
 			}
 
@@ -1215,7 +1224,8 @@
 
 				for (var j = 0; j < preview.data.length; j++)
 				{
-					if (skipEmptyLines && preview.data[j].length === 1 && preview.data[j][0].length === 0) {
+					if (skipEmptyLines && testEmptyLine(preview.data[j], delim))
+					{
 						emptyLinesCount++;
 						continue;
 					}

--- a/papaparse.js
+++ b/papaparse.js
@@ -1078,8 +1078,6 @@
 		function testEmptyLine(s, d) {
 			var q = _config.quoteChar || '"';
 			var r = _config.skipNoContentLines ? new RegExp('^[' + escapeRegExp(d) + escapeRegExp(q) + '\\s]*$') : new RegExp('^$');
-			// var q = _config.quoteChar || '"';
-			// var r = _config.skipNoContentLines ? new RegExp('^[' + d + q + '\\s]*$') : new RegExp('^$');
 			for (var i = 0; i < s.length; i++)
 				if (r.test(s[i]))
 					return true;

--- a/papaparse.js
+++ b/papaparse.js
@@ -1295,6 +1295,7 @@
 		}
 	}
 
+	/** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions */
 	function escapeRegExp(string)
 	{
 		return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string

--- a/papaparse.js
+++ b/papaparse.js
@@ -1077,7 +1077,9 @@
 
 		function testEmptyLine(s, d) {
 			var q = _config.quoteChar || '"';
-			var r = _config.skipNoContentLines ? new RegExp('^[' + d + q + '\\s]*$') : new RegExp('^$');
+			var r = _config.skipNoContentLines ? new RegExp('^[' + escapeRegExp(d) + escapeRegExp(q) + '\\s]*$') : new RegExp('^$');
+			// var q = _config.quoteChar || '"';
+			// var r = _config.skipNoContentLines ? new RegExp('^[' + d + q + '\\s]*$') : new RegExp('^$');
 			for (var i = 0; i < s.length; i++)
 				if (r.test(s[i]))
 					return true;
@@ -1300,8 +1302,8 @@
 		}
 	}
 
-	/** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions */
-	function escapeRegExp(string) {
+	function escapeRegExp(string)
+	{
 		return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 	}
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1340,10 +1340,10 @@ var PARSE_TESTS = [
 		}
 	},
 	{
-		description: "Parsing with skipEmptyLines set to 'strict'",
+		description: "Parsing with skipEmptyLines set to 'greedy'",
 		notes: "Must parse correctly without lines with no content",
 		input: 'a,b\n\n,\nc,d\n , \n""," "\n " " , " "\n,,,,\n",,,",","\n',
-		config: { skipEmptyLines: 'strict' },
+		config: { skipEmptyLines: 'greedy' },
 		expected: {
 			data: [['a', 'b'], ['c', 'd']],
 			errors: []
@@ -1353,7 +1353,7 @@ var PARSE_TESTS = [
 		description: "Parsing with skipNoContentLines and regex special char as quoteChar",
 		notes: "Must skip lines correctly with reserved regex char as quoteChar",
 		input: 'a,b\n\n,\nc,d\n , \n]],] ]\n ] ] , ] ]\n,,,,\n],,,],],]\n',
-		config: { skipEmptyLines: 'strict', quoteChar: ']' },
+		config: { skipEmptyLines: 'greedy', quoteChar: ']' },
 		expected: {
 			data: [['a', 'b'], ['c', 'd']],
 			errors: []
@@ -1363,7 +1363,7 @@ var PARSE_TESTS = [
 		description: "Parsing with skipNoContentLines and regex special char as delimiter",
 		notes: "Must skip lines correctly with reserved regex char as delimiter",
 		input: 'a]b\n\n]\nc]d\n ] \n""]" "\n " " ] " "\n]]]]\n"]]]"]"]"\n',
-		config: { skipEmptyLines: 'strict', delimiter: ']' },
+		config: { skipEmptyLines: 'greedy', delimiter: ']' },
 		expected: {
 			data: [['a', 'b'], ['c', 'd']],
 			errors: []

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1338,6 +1338,16 @@ var PARSE_TESTS = [
 				truncated: false
 			}
 		}
+	},
+	{
+		description: "Parsing with skipNoContentLines",
+		notes: "Must parse correctly without lines with no content",
+		input: 'a,b\n\n,\nc,d\n , \n""," "\n " " , " "\n,,,,\n",,,",","\n',
+		config: { skipEmptyLines: true, skipNoContentLines: true },
+		expected: {
+			data: [['a', 'b'], ['c', 'd']],
+			errors: []
+		}
 	}
 ];
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1350,7 +1350,7 @@ var PARSE_TESTS = [
 		}
 	},
 	{
-		description: "Parsing with skipNoContentLines and regex special char as quoteChar",
+		description: "Parsing with skipEmptyLines set to 'greedy' and regex special char as quoteChar",
 		notes: "Must skip lines correctly with reserved regex char as quoteChar",
 		input: 'a,b\n\n,\nc,d\n , \n]],] ]\n ] ] , ] ]\n,,,,\n],,,],],]\n',
 		config: { skipEmptyLines: 'greedy', quoteChar: ']' },
@@ -1360,7 +1360,7 @@ var PARSE_TESTS = [
 		}
 	},
 	{
-		description: "Parsing with skipNoContentLines and regex special char as delimiter",
+		description: "Parsing with skipEmptyLines set to 'greedy' and regex special char as delimiter",
 		notes: "Must skip lines correctly with reserved regex char as delimiter",
 		input: 'a]b\n\n]\nc]d\n ] \n""]" "\n " " ] " "\n]]]]\n"]]]"]"]"\n',
 		config: { skipEmptyLines: 'greedy', delimiter: ']' },

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1342,7 +1342,7 @@ var PARSE_TESTS = [
 	{
 		description: "Parsing with skipEmptyLines set to 'greedy'",
 		notes: "Must parse correctly without lines with no content",
-		input: 'a,b\n\n,\nc,d\n , \n""," "\n " " , " "\n,,,,\n",,,",","\n',
+		input: 'a,b\n\n,\nc,d\n , \n""," "\n	,	\n,,,,\n',
 		config: { skipEmptyLines: 'greedy' },
 		expected: {
 			data: [['a', 'b'], ['c', 'd']],
@@ -1350,22 +1350,12 @@ var PARSE_TESTS = [
 		}
 	},
 	{
-		description: "Parsing with skipEmptyLines set to 'greedy' and regex special char as quoteChar",
-		notes: "Must skip lines correctly with reserved regex char as quoteChar",
-		input: 'a,b\n\n,\nc,d\n , \n]],] ]\n ] ] , ] ]\n,,,,\n],,,],],]\n',
-		config: { skipEmptyLines: 'greedy', quoteChar: ']' },
+		description: "Parsing with skipEmptyLines set to 'greedy' with quotes and delimiters as content",
+		notes: "Must include lines with escaped delimiters and quotes",
+		input: 'a,b\n\n,\nc,d\n" , ",","\n""" """,""""""\n\n\n',
+		config: { skipEmptyLines: 'greedy' },
 		expected: {
-			data: [['a', 'b'], ['c', 'd']],
-			errors: []
-		}
-	},
-	{
-		description: "Parsing with skipEmptyLines set to 'greedy' and regex special char as delimiter",
-		notes: "Must skip lines correctly with reserved regex char as delimiter",
-		input: 'a]b\n\n]\nc]d\n ] \n""]" "\n " " ] " "\n]]]]\n"]]]"]"]"\n',
-		config: { skipEmptyLines: 'greedy', delimiter: ']' },
-		expected: {
-			data: [['a', 'b'], ['c', 'd']],
+			data: [['a', 'b'], ['c', 'd'], [' , ', ','], ['" "', '""']],
 			errors: []
 		}
 	}

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1358,6 +1358,26 @@ var PARSE_TESTS = [
 			data: [['a', 'b'], ['c', 'd']],
 			errors: []
 		}
+	},
+	{
+		description: "Parsing with skipNoContentLines and regex special char as quoteChar",
+		notes: "Must skip lines correctly with reserved regex char as quoteChar",
+		input: 'a,b\n\n,\nc,d\n , \n]],] ]\n ] ] , ] ]\n,,,,\n],,,],],]\n',
+		config: { skipNoContentLines: true, quoteChar: ']' },
+		expected: {
+			data: [['a', 'b'], ['c', 'd']],
+			errors: []
+		}
+	},
+	{
+		description: "Parsing with skipNoContentLines and regex special char as delimiter",
+		notes: "Must skip lines correctly with reserved regex char as delimiter",
+		input: 'a]b\n\n]\nc]d\n ] \n""]" "\n " " ] " "\n]]]]\n"]]]"]"]"\n',
+		config: { skipNoContentLines: true, delimiter: ']' },
+		expected: {
+			data: [['a', 'b'], ['c', 'd']],
+			errors: []
+		}
 	}
 ];
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1340,20 +1340,10 @@ var PARSE_TESTS = [
 		}
 	},
 	{
-		description: "Parsing with skipNoContentLines and skipEmptyLines",
+		description: "Parsing with skipEmptyLines set to 'strict'",
 		notes: "Must parse correctly without lines with no content",
 		input: 'a,b\n\n,\nc,d\n , \n""," "\n " " , " "\n,,,,\n",,,",","\n',
-		config: { skipEmptyLines: true, skipNoContentLines: true },
-		expected: {
-			data: [['a', 'b'], ['c', 'd']],
-			errors: []
-		}
-	},
-	{
-		description: "Parsing with just skipNoContentLines",
-		notes: "Must parse correctly without lines with no content",
-		input: 'a,b\n\n,\nc,d\n , \n""," "\n " " , " "\n,,,,\n",,,",","\n',
-		config: { skipNoContentLines: true },
+		config: { skipEmptyLines: 'strict' },
 		expected: {
 			data: [['a', 'b'], ['c', 'd']],
 			errors: []
@@ -1363,7 +1353,7 @@ var PARSE_TESTS = [
 		description: "Parsing with skipNoContentLines and regex special char as quoteChar",
 		notes: "Must skip lines correctly with reserved regex char as quoteChar",
 		input: 'a,b\n\n,\nc,d\n , \n]],] ]\n ] ] , ] ]\n,,,,\n],,,],],]\n',
-		config: { skipNoContentLines: true, quoteChar: ']' },
+		config: { skipEmptyLines: 'strict', quoteChar: ']' },
 		expected: {
 			data: [['a', 'b'], ['c', 'd']],
 			errors: []
@@ -1373,7 +1363,7 @@ var PARSE_TESTS = [
 		description: "Parsing with skipNoContentLines and regex special char as delimiter",
 		notes: "Must skip lines correctly with reserved regex char as delimiter",
 		input: 'a]b\n\n]\nc]d\n ] \n""]" "\n " " ] " "\n]]]]\n"]]]"]"]"\n',
-		config: { skipNoContentLines: true, delimiter: ']' },
+		config: { skipEmptyLines: 'strict', delimiter: ']' },
 		expected: {
 			data: [['a', 'b'], ['c', 'd']],
 			errors: []

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1340,10 +1340,20 @@ var PARSE_TESTS = [
 		}
 	},
 	{
-		description: "Parsing with skipNoContentLines",
+		description: "Parsing with skipNoContentLines and skipEmptyLines",
 		notes: "Must parse correctly without lines with no content",
 		input: 'a,b\n\n,\nc,d\n , \n""," "\n " " , " "\n,,,,\n",,,",","\n',
 		config: { skipEmptyLines: true, skipNoContentLines: true },
+		expected: {
+			data: [['a', 'b'], ['c', 'd']],
+			errors: []
+		}
+	},
+	{
+		description: "Parsing with just skipNoContentLines",
+		notes: "Must parse correctly without lines with no content",
+		input: 'a,b\n\n,\nc,d\n , \n""," "\n " " , " "\n,,,,\n",,,",","\n',
+		config: { skipNoContentLines: true },
 		expected: {
 			data: [['a', 'b'], ['c', 'd']],
 			errors: []


### PR DESCRIPTION
Added a boolean config value `skipNoContentLines` which skips lines that only contain delimiters, quotes, and whitespace, instead of just lines that evaluate to an empty string. Works if set alongside `skipEmptyLines` or on its own. Passing tests are included.