### PR TITLE
Use 'greedy' skipEmptyLines in unparse

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -293,9 +293,9 @@
 		if (_input instanceof Array)
 		{
 			if (!_input.length || _input[0] instanceof Array)
-				return serialize(null, _input, _skipEmptyLines === 'greedy');
+				return serialize(null, _input, _skipEmptyLines);
 			else if (typeof _input[0] === 'object')
-				return serialize(objectKeys(_input[0]), _input, _skipEmptyLines === 'greedy');
+				return serialize(objectKeys(_input[0]), _input, _skipEmptyLines);
 		}
 		else if (typeof _input === 'object')
 		{
@@ -316,7 +316,7 @@
 					_input.data = [_input.data];	// handles input like [1,2,3] or ['asdf']
 			}
 
-			return serialize(_input.fields || [], _input.data || [], _skipEmptyLines === 'greedy');
+			return serialize(_input.fields || [], _input.data || [], _skipEmptyLines);
 		}
 
 		// Default (any valid paths should return before this)
@@ -365,7 +365,7 @@
 		}
 
 		/** The double for loop that iterates the data and writes out a CSV string including header row */
-		function serialize(fields, data, greedySkip)
+		function serialize(fields, data, skipEmptyLines)
 		{
 			var csv = '';
 
@@ -394,8 +394,9 @@
 			for (var row = 0; row < data.length; row++)
 			{
 				var maxCol = hasHeader ? fields.length : data[row].length;
+				var r = hasHeader ? fields : data[row];
 
-				if (!greedySkip || data[row].join('').trim() !== '')
+				if (skipEmptyLines !== 'greedy' || r.join('').trim() !== '')
 				{
 					for (var col = 0; col < maxCol; col++)
 					{
@@ -404,7 +405,7 @@
 						var colIdx = hasHeader && dataKeyedByField ? fields[col] : col;
 						csv += safe(data[row][colIdx], col);
 					}
-					if (row < data.length - 1)
+					if (row < data.length - 1 && (!skipEmptyLines || maxCol > 0))
 						csv += _newline;
 				}
 			}

--- a/papaparse.js
+++ b/papaparse.js
@@ -280,6 +280,9 @@
 		/** quote character */
 		var _quoteChar = '"';
 
+		/** whether to skip empty lines */
+		var _skipEmptyLines = false;
+
 		unpackConfig();
 
 		var quoteCharRegex = new RegExp(_quoteChar, 'g');
@@ -290,9 +293,9 @@
 		if (_input instanceof Array)
 		{
 			if (!_input.length || _input[0] instanceof Array)
-				return serialize(null, _input);
+				return serialize(null, _input, _skipEmptyLines === 'greedy');
 			else if (typeof _input[0] === 'object')
-				return serialize(objectKeys(_input[0]), _input);
+				return serialize(objectKeys(_input[0]), _input, _skipEmptyLines === 'greedy');
 		}
 		else if (typeof _input === 'object')
 		{
@@ -313,7 +316,7 @@
 					_input.data = [_input.data];	// handles input like [1,2,3] or ['asdf']
 			}
 
-			return serialize(_input.fields || [], _input.data || []);
+			return serialize(_input.fields || [], _input.data || [], _skipEmptyLines === 'greedy');
 		}
 
 		// Default (any valid paths should return before this)
@@ -334,6 +337,10 @@
 			if (typeof _config.quotes === 'boolean'
 				|| _config.quotes instanceof Array)
 				_quotes = _config.quotes;
+
+			if (typeof _config.skipEmptyLines === 'boolean'
+				|| typeof _config.skipEmptyLines === 'string')
+				_skipEmptyLines = _config.skipEmptyLines;
 
 			if (typeof _config.newline === 'string')
 				_newline = _config.newline;
@@ -358,7 +365,7 @@
 		}
 
 		/** The double for loop that iterates the data and writes out a CSV string including header row */
-		function serialize(fields, data)
+		function serialize(fields, data, greedySkip)
 		{
 			var csv = '';
 
@@ -388,18 +395,19 @@
 			{
 				var maxCol = hasHeader ? fields.length : data[row].length;
 
-				for (var col = 0; col < maxCol; col++)
+				if (!greedySkip || data[row].join('').trim() !== '')
 				{
-					if (col > 0)
-						csv += _delimiter;
-					var colIdx = hasHeader && dataKeyedByField ? fields[col] : col;
-					csv += safe(data[row][colIdx], col);
+					for (var col = 0; col < maxCol; col++)
+					{
+						if (col > 0)
+							csv += _delimiter;
+						var colIdx = hasHeader && dataKeyedByField ? fields[col] : col;
+						csv += safe(data[row][colIdx], col);
+					}
+					if (row < data.length - 1)
+						csv += _newline;
 				}
-
-				if (row < data.length - 1)
-					csv += _newline;
 			}
-
 			return csv;
 		}
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1638,15 +1638,15 @@ var UNPARSE_TESTS = [
 		expected: 'date,not a date\r\n2018-05-04T21:08:03.269Z,16\r\n2018-05-08T15:20:22.000Z,32'
 	},
 	{
-		description: "Returns empty rows when no content is passed and skipEmptyLines is false",
+		description: "Returns empty rows when empty rows are passed and skipEmptyLines is false",
 		input: [[null, ' '], [], ['1', '2']],
 		config: {skipEmptyLines: false},
 		expected: '," "\r\n\r\n1,2'
 	},
 	{
-		description: "Returns without empty rows and skipEmptyLines is true",
+		description: "Returns without empty rows when skipEmptyLines is true",
 		input: [[null, ' '], [], ['1', '2']],
-		config: {skipEmptyLines: false},
+		config: {skipEmptyLines: true},
 		expected: '," "\r\n1,2'
 	},
 	{

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1636,6 +1636,18 @@ var UNPARSE_TESTS = [
 		description: "Date objects are exported in its ISO representation",
 		input: [{date: new Date("2018-05-04T21:08:03.269Z"), "not a date": 16}, {date: new Date("Tue May 08 2018 08:20:22 GMT-0700 (PDT)"), "not a date": 32}],
 		expected: 'date,not a date\r\n2018-05-04T21:08:03.269Z,16\r\n2018-05-08T15:20:22.000Z,32'
+	},
+	{
+		description: "Returns empty rows when no content is passed and skipEmptyLines is true",
+		input: [[null, ' '], [], ['1', '2']],
+		config: {skipEmptyLines: true},
+		expected: '," "\r\n\r\n1,2'
+	},
+	{
+		description: "Returns without rows with no content when skipEmptyLines is 'greedy'",
+		input: [[null, ' '], [], ['1', '2']],
+		config: {skipEmptyLines: 'greedy'},
+		expected: '1,2'
 	}
 ];
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1638,10 +1638,16 @@ var UNPARSE_TESTS = [
 		expected: 'date,not a date\r\n2018-05-04T21:08:03.269Z,16\r\n2018-05-08T15:20:22.000Z,32'
 	},
 	{
-		description: "Returns empty rows when no content is passed and skipEmptyLines is true",
+		description: "Returns empty rows when no content is passed and skipEmptyLines is false",
 		input: [[null, ' '], [], ['1', '2']],
-		config: {skipEmptyLines: true},
+		config: {skipEmptyLines: false},
 		expected: '," "\r\n\r\n1,2'
+	},
+	{
+		description: "Returns without empty rows and skipEmptyLines is true",
+		input: [[null, ' '], [], ['1', '2']],
+		config: {skipEmptyLines: false},
+		expected: '," "\r\n1,2'
 	},
 	{
 		description: "Returns without rows with no content when skipEmptyLines is 'greedy'",


### PR DESCRIPTION
Added support for skipEmptyLines in unparsing using both `true` and `'greedy'` values.

Resolves #553 