### PR TITLE
Fixes unparsing using 'skipEmptyLines' = 'greedy' when using headers

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -398,7 +398,9 @@
 				var emptyLine = false;
 				var nullLine = hasHeader ? Object.keys(data[row]).length === 0 : data[row].length === 0;
 				if (skipEmptyLines && !hasHeader)
+				{
 					emptyLine = skipEmptyLines === 'greedy' ? data[row].join('').trim() === '' : data[row].length === 1 && data[row][0].length === 0;
+				}
 				if (skipEmptyLines === 'greedy' && hasHeader) {
 					var line = [];
 					for (var c = 0; c < maxCol; c++) {
@@ -416,8 +418,10 @@
 						var colIdx = hasHeader && dataKeyedByField ? fields[col] : col;
 						csv += safe(data[row][colIdx], col);
 					}
-					if (row < data.length - 1 && (!skipEmptyLines || maxCol > 0) && (!skipEmptyLines || !nullLine))
+					if (row < data.length - 1 && (!skipEmptyLines || (maxCol > 0 && !nullLine)))
+					{
 						csv += _newline;
+					}
 				}
 			}
 			return csv;

--- a/papaparse.js
+++ b/papaparse.js
@@ -394,18 +394,29 @@
 			for (var row = 0; row < data.length; row++)
 			{
 				var maxCol = hasHeader ? fields.length : data[row].length;
-				var r = hasHeader ? fields : data[row];
 
-				if (skipEmptyLines !== 'greedy' || r.join('').trim() !== '')
+				var emptyLine = false;
+				var nullLine = hasHeader ? Object.keys(data[row]).length === 0 : data[row].length === 0;
+				if (skipEmptyLines && !hasHeader)
+					emptyLine = skipEmptyLines === 'greedy' ? data[row].join('').trim() === '' : data[row].length === 1 && data[row][0].length === 0;
+				if (skipEmptyLines === 'greedy' && hasHeader) {
+					var line = [];
+					for (var c = 0; c < maxCol; c++) {
+						var cx = dataKeyedByField ? fields[c] : c;
+						line.push(data[row][cx]);
+					}
+					emptyLine = line.join('').trim() === '';
+				}
+				if (!emptyLine)
 				{
 					for (var col = 0; col < maxCol; col++)
 					{
-						if (col > 0)
+						if (col > 0 && !nullLine)
 							csv += _delimiter;
 						var colIdx = hasHeader && dataKeyedByField ? fields[col] : col;
 						csv += safe(data[row][colIdx], col);
 					}
-					if (row < data.length - 1 && (!skipEmptyLines || maxCol > 0))
+					if (row < data.length - 1 && (!skipEmptyLines || maxCol > 0) && (!skipEmptyLines || !nullLine))
 						csv += _newline;
 				}
 			}

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1654,6 +1654,24 @@ var UNPARSE_TESTS = [
 		input: [[null, ' '], [], ['1', '2']],
 		config: {skipEmptyLines: 'greedy'},
 		expected: '1,2'
+	},
+	{
+		description: "Returns empty rows when empty rows are passed and skipEmptyLines is false with headers",
+		input: [{a: null, b: ' '}, {}, {a: '1', b: '2'}],
+		config: {skipEmptyLines: false, header: true},
+		expected: 'a,b\r\n," "\r\n\r\n1,2'
+	},
+	{
+		description: "Returns without empty rows when skipEmptyLines is true with headers",
+		input: [{a: null, b: ' '}, {}, {a: '1', b: '2'}],
+		config: {skipEmptyLines: true, header: true},
+		expected: 'a,b\r\n," "\r\n1,2'
+	},
+	{
+		description: "Returns without rows with no content when skipEmptyLines is 'greedy' with headers",
+		input: [{a: null, b: ' '}, {}, {a: '1', b: '2'}],
+		config: {skipEmptyLines: 'greedy', header: true},
+		expected: 'a,b\r\n1,2'
 	}
 ];
 


### PR DESCRIPTION
Resolves https://github.com/mholt/PapaParse/issues/558

See also:

* [#553 (comment)](https://github.com/mholt/PapaParse/issues/553#issuecomment-413287866)
* #554