### PR TITLE
[Rework Worker Definition] Make Bundling/Concatenation safe

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -749,12 +749,6 @@ var csv = Papa.unparse({
 									Whether or not the browser supports HTML5 Web Workers. If false, <code>worker: true</code> will have no effect.
 								</td>
 							</tr>
-							<tr>
-								<td><code>Papa.SCRIPT_PATH</code></td>
-								<td>
-									The relative path to Papa Parse. This is automatically detected when Papa Parse is loaded synchronously. However, if you load Papa Parse asynchronously (e.g. with RequireJS), you need to set this variable manually in order to use Web Workers. (In those cases, this variable is <i>not</i> read-only and you should set it!)
-								</td>
-							</tr>
 						</table>
 					</div>
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -447,7 +447,7 @@ var csv = Papa.unparse({
 									<code>worker</code>
 								</td>
 								<td>
-									Whether or not to use a <a href="/faq#workers">worker thread</a>. Using a worker will keep your page reactive, but may be slightly slower. Web Workers also load the entire Javascript file, so be careful when <a href="/faq#combine">combining other libraries</a> in the same file as Papa Parse. Note that worker option is only available when parsing files and not when converting from JSON to CSV.
+									Whether or not to use a <a href="/faq#workers">worker thread</a>. Using a worker will keep your page reactive, but may be slightly slower.
 								</td>
 							</tr>
 							<tr>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -84,7 +84,7 @@
 
 					<h6 id="combine">Can I put other libraries in the same file as Papa Parse?</h6>
 					<p>
-						Yes, but then don't use the Web Worker feature unless your other dependencies are battle-hardened for worker threads. A worker thread loads an entire file, not just a function, so all those dependencies would be executed in an environment without a DOM and other <code>window</code> features. If any of those dependencies crash (<code>Cannot read property "defaultView" of undefined</code> <a href="https://github.com/mholt/PapaParse/issues/114">is</a> <a href="https://github.com/mholt/PapaParse/issues/163">common</a>), the whole worker thread will crash and parsing will not succeed.
+						Yes.
 					</p>
 
 
@@ -96,7 +96,7 @@
 
 					<h6 id="async">Can Papa Parse be loaded asynchronously (after the page loads)?</h6>
 					<p>
-						Yes.
+						Yes. 
 					</p>
 
 
@@ -209,7 +209,7 @@
 
 					<h6>Can I use a worker if I combine/concatenate my Javascript files?</h6>
 					<p>
-						Probably not. It's safest to concatenate the rest of your dependencies and include Papa Parse in a seperate file. Any library that expects to have access to the <code>window</code> or DOM will crash when executed in a worker thread. Only put <a href="/faq#combine">other libraries in the same file</a> if they are ready to be used in worker threads.
+						Yes.
 					</p>
 
 					<h6>When should I use a worker?</h6>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -96,7 +96,7 @@
 
 					<h6 id="async">Can Papa Parse be loaded asynchronously (after the page loads)?</h6>
 					<p>
-						Yes. But if you want to use Web Workers, you'll need to specify the relative path to Papa Parse. To do this, set <a href="/docs#readonly">Papa.SCRIPT_PATH</a> to the relative path of the Papa Parse file. In synchronous loading, this is automatically detected.
+						Yes.
 					</p>
 
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
 		"mocha": "^5.2.0",
 		"mocha-headless-chrome": "^2.0.1",
 		"open": "0.0.5",
-		"phantomjs-prebuilt": "^2.1.16",
 		"serve-static": "^1.7.1"
 	},
 	"scripts": {

--- a/papaparse.js
+++ b/papaparse.js
@@ -62,8 +62,7 @@ if (!Array.isArray)
 	}
 
 	var IS_WORKER = !global.document && !!global.postMessage,
-		IS_PAPA_WORKER = IS_WORKER && (/blob:/i.test(global.location.protocol) || /(\?|&)papaworker(=|&|$)/.test(global.location.search)),
-		LOADED_SYNC = false, AUTO_SCRIPT_PATH;
+		IS_PAPA_WORKER = IS_WORKER && /blob:/i.test((global.location || {}).protocol);
 	var workers = {}, workerIdCounter = 0;
 
 	var Papa = {};
@@ -76,7 +75,6 @@ if (!Array.isArray)
 	Papa.BYTE_ORDER_MARK = '\ufeff';
 	Papa.BAD_DELIMITERS = ['\r', '\n', '"', Papa.BYTE_ORDER_MARK];
 	Papa.WORKERS_SUPPORTED = !IS_WORKER && !!global.Worker;
-	Papa.SCRIPT_PATH = null;	// Must be set by your code if you use workers and this lib is loaded asynchronously
 	Papa.NODE_STREAM_INPUT = 1;
 
 	// Configurable chunk sizes for local and remote files, respectively
@@ -193,23 +191,6 @@ if (!Array.isArray)
 	if (IS_PAPA_WORKER)
 	{
 		global.onmessage = workerThreadReceivedMessage;
-	}
-	else if (Papa.WORKERS_SUPPORTED)
-	{
-		AUTO_SCRIPT_PATH = getScriptPath();
-
-		// Check if the script was loaded synchronously
-		if (!document.body)
-		{
-			// Body doesn't exist yet, must be synchronous
-			LOADED_SYNC = true;
-		}
-		else
-		{
-			document.addEventListener('DOMContentLoaded', function() {
-				LOADED_SYNC = true;
-			}, true);
-		}
 	}
 
 
@@ -1695,28 +1676,12 @@ if (!Array.isArray)
 	}
 
 
-	// If you need to load Papa Parse asynchronously and you also need worker threads, hard-code
-	// the script path here. See: https://github.com/mholt/PapaParse/issues/87#issuecomment-57885358
-	function getScriptPath()
-	{
-		var scripts = document.getElementsByTagName('script');
-		return scripts.length ? scripts[scripts.length - 1].src : '';
-	}
-
 	function newWorker()
 	{
 		if (!Papa.WORKERS_SUPPORTED)
 			return false;
-		if (!LOADED_SYNC && Papa.SCRIPT_PATH === null)
-			throw new Error(
-				'Script path cannot be determined automatically when Papa Parse is loaded asynchronously. ' +
-				'You need to set Papa.SCRIPT_PATH manually.'
-			);
-		var workerUrl = Papa.SCRIPT_PATH || AUTO_SCRIPT_PATH;
-		// Append 'papaworker' to the search string to tell papaparse that this is our worker.
-		workerUrl += (workerUrl.indexOf('?') !== -1 ? '&' : '?') + 'papaworker';
-		if (Papa.SCRIPT_PATH === 'blob')
-			workerUrl = getWorkerBlob();
+
+		var workerUrl = getWorkerBlob();
 		var w = new global.Worker(workerUrl);
 		w.onmessage = mainThreadReceivedMessage;
 		w.id = workerIdCounter++;

--- a/papaparse.js
+++ b/papaparse.js
@@ -56,13 +56,9 @@ if (!Array.isArray)
 
 
 	function getWorkerBlob() {
-		try {
-			var URL = global.URL || global.webkitURL || null;
-			var code = moduleFactory.toString();
-			return Papa.BLOB_URL || (Papa.BLOB_URL = URL.createObjectURL(new Blob(['(', code, ')();'], {type: 'text/javascript'})));
-		} catch (e) {
-			return null;
-		}
+		var URL = global.URL || global.webkitURL || null;
+		var code = moduleFactory.toString();
+		return Papa.BLOB_URL || (Papa.BLOB_URL = URL.createObjectURL(new Blob(['(', code, ')();'], {type: 'text/javascript'})));
 	}
 
 	var IS_WORKER = !global.document && !!global.postMessage,

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -7,6 +7,7 @@ if (typeof module !== 'undefined' && module.exports) {
 
 var assert = chai.assert;
 
+var BASE_PATH = (typeof document === 'undefined') ? './' : document.getElementById('test-cases').src.replace(/test-cases\.js$/, '');
 var RECORD_SEP = String.fromCharCode(30);
 var UNIT_SEP = String.fromCharCode(31);
 var FILES_ENABLED = false;
@@ -1396,7 +1397,7 @@ var PARSE_ASYNC_TESTS = [
 	},
 	{
 		description: "Simple download",
-		input: "sample.csv",
+		input: BASE_PATH + "sample.csv",
 		config: {
 			download: true
 		},
@@ -1408,7 +1409,7 @@ var PARSE_ASYNC_TESTS = [
 	},
 	{
 		description: "Simple download + worker",
-		input: "tests/sample.csv",
+		input: BASE_PATH + "sample.csv",
 		config: {
 			worker: true,
 			download: true
@@ -1761,7 +1762,7 @@ var CUSTOM_TESTS = [
 		disabled: !XHR_ENABLED,
 		run: function(callback) {
 			var updates = [];
-			Papa.parse("/tests/long-sample.csv", {
+			Papa.parse(BASE_PATH + "long-sample.csv", {
 				download: true,
 				step: function(response) {
 					updates.push(response.meta.cursor);
@@ -1778,7 +1779,7 @@ var CUSTOM_TESTS = [
 		disabled: !XHR_ENABLED,
 		run: function(callback) {
 			var updates = [];
-			Papa.parse("/tests/long-sample.csv", {
+			Papa.parse(BASE_PATH + "long-sample.csv", {
 				download: true,
 				chunkSize: 500,
 				step: function(response) {
@@ -1796,7 +1797,7 @@ var CUSTOM_TESTS = [
 		disabled: !XHR_ENABLED,
 		run: function(callback) {
 			var updates = [];
-			Papa.parse("/tests/long-sample.csv", {
+			Papa.parse(BASE_PATH + "long-sample.csv", {
 				download: true,
 				chunkSize: 500,
 				worker: true,
@@ -1815,7 +1816,7 @@ var CUSTOM_TESTS = [
 		disabled: !XHR_ENABLED,
 		run: function(callback) {
 			var updates = [];
-			Papa.parse("/tests/long-sample.csv", {
+			Papa.parse(BASE_PATH + "long-sample.csv", {
 				download: true,
 				chunkSize: 500,
 				chunk: function(response) {
@@ -1833,7 +1834,7 @@ var CUSTOM_TESTS = [
 		disabled: !XHR_ENABLED,
 		run: function(callback) {
 			var updates = [];
-			Papa.parse("/tests/long-sample.csv", {
+			Papa.parse(BASE_PATH + "long-sample.csv", {
 				download: true,
 				chunkSize: 500,
 				chunk: function(response) {
@@ -2042,7 +2043,7 @@ var CUSTOM_TESTS = [
 		disabled: !XHR_ENABLED,
 		run: function(callback) {
 			var updates = 0;
-			Papa.parse("/tests/long-sample.csv", {
+			Papa.parse(BASE_PATH + "long-sample.csv", {
 				worker: true,
 				download: true,
 				chunkSize: 500,
@@ -2062,7 +2063,7 @@ var CUSTOM_TESTS = [
 		disabled: !XHR_ENABLED,
 		run: function(callback) {
 			var updates = 0;
-			Papa.parse("/tests/long-sample.csv", {
+			Papa.parse(BASE_PATH + "long-sample.csv", {
 				download: true,
 				chunkSize: 500,
 				beforeFirstChunk: function(chunk) {
@@ -2083,7 +2084,7 @@ var CUSTOM_TESTS = [
 		disabled: !XHR_ENABLED,
 		run: function(callback) {
 			var updates = 0;
-			Papa.parse("/tests/long-sample.csv", {
+			Papa.parse(BASE_PATH + "long-sample.csv", {
 				download: true,
 				chunkSize: 500,
 				beforeFirstChunk: function(chunk) {
@@ -2094,37 +2095,6 @@ var CUSTOM_TESTS = [
 				complete: function() {
 					callback(updates);
 				}
-			});
-		}
-	},
-	{
-		description: "Should not assume we own the worker unless papaworker is in the search string",
-		disabled: typeof Worker === 'undefined',
-		expected: [false, true, true, true, true],
-		run: function(callback) {
-			var searchStrings = [
-				'',
-				'?papaworker',
-				'?x=1&papaworker',
-				'?x=1&papaworker&y=1',
-				'?x=1&papaworker=1'
-			];
-			var results = searchStrings.map(function() { return false; });
-			var workers = [];
-
-			// Give it .5s to do something
-			setTimeout(function() {
-				workers.forEach(function(w) { w.terminate(); });
-				callback(results);
-			}, 500);
-
-			searchStrings.forEach(function(searchString, idx) {
-				var w = new Worker('../papaparse.js' + searchString);
-				workers.push(w);
-				w.addEventListener('message', function() {
-					results[idx] = true;
-				});
-				w.postMessage({input: 'a,b,c\n1,2,3'});
 			});
 		}
 	}

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -9,7 +9,7 @@
 		<script src="../node_modules/chai/chai.js"></script>
 
 		<script>mocha.setup('bdd')</script>
-		<script src="test-cases.js"></script>
+		<script src="test-cases.js" id="test-cases"></script>
 	</head>
 	<body>
 	<div id="mocha"></div>

--- a/tests/tests.html
+++ b/tests/tests.html
@@ -15,13 +15,8 @@
 	<div id="mocha"></div>
 
 	<script>
-		if (window.mochaPhantomJS) {
-			mochaPhantomJS.run();
-
-		} else {
-			mocha.checkLeaks();
-			mocha.run();
-		}
+		mocha.checkLeaks();
+		mocha.run();
 	</script>
 	</body>
 </html>


### PR DESCRIPTION
This addresses a few issues with using the worker and bundlers (such as rollup/webpack) I believe these issues are related and fixes: #273,  #426, #525

With this change, you could completely drop the SCRIPT_PATH option all together or default it to use the generated blob.