### PR TITLE
add table for unparse config options

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -228,7 +228,7 @@
 
 
 					<div class="grid-50">
-						<pre><code class="language-javascript">Papa.unparse(data<i>[, config]</i>)</code></pre>
+						<pre><code class="language-javascript">Papa.unparse(data<i>[, <a href="#unparse-config-default">config</a>]</i>)</code></pre>
 					</div>
 
 					<div class="grid-50">
@@ -243,19 +243,88 @@
 								</ul>
 							</li>
 							<li>
-								<code>config</code> is an optional object with any of these properties:
-								<pre><code class="language-javascript">// defaults shown
+								<code>config</code> is an optional <a href="#unparse-config-default">config object</a>
+							</li>
+						</ul>
+					</div>
+					<div class="clear"></div>
+
+				<div class="grid-100">
+				<h5 id="unparse-config-default">Default Unparse Config with all options</h5>
+				</div>
+
+					<div class="prefix-25 grid-50 suffix-25">
+					<pre><code class="language-javascript">
 {
-	quotes: false,
+	quotes: false, //or array of booleans
 	quoteChar: '"',
 	delimiter: ",",
 	header: true,
 	newline: "\r\n",
 	skipEmptyLines: false, //or 'greedy'
-}</code></pre>
-																			Set <code>quotes</code> to <code>true</code> to always enclose each field in quotes, or an array of true/false values correlating to specific to columns to force-quote. The character used to quote can be customized using <code>quoteChar</code>. The <code>delimiter</code> can be any valid delimiting character. The <code>newline</code> character(s) may also be customized. Setting <code>header</code> to <code>false</code> will omit the header row. Setting <code>skipEmptyLines</code> to <code>true</code> will skip completely empty rows (those which evaluate to an empty string). If set to <code>'greedy'</code>, rows that don't have any content (those which have only whitespace after unparsing) will also be skipped.</code>
-							</li>
-						</ul>
+}
+					</code></pre>
+				</div>
+
+					<div class="clear"></div>
+
+					<div class="grid-100">
+						<h5>Unparse Config Options</h5>
+					</div>
+
+					<div class="grid-100" style="overflow-x: auto;">
+						<table>
+							<tr>
+								<th style="width: 20%;">Option</th>
+								<th style="width: 80%;">Explanation</th>
+							</tr>
+							<tr>
+								<td>
+									<code>quotes</code>
+								</td>
+								<td>
+									If <code>true</code>, forces all fields to be enclosed in quotes. If an array of <code>true/false</code> values, specifies which fields should be force-quoted (first boolean is for the first column, second boolean for the second column, ...).
+								</td>
+							</tr>
+							<tr>
+								<td><code>quoteChar</code></td>
+								<td>
+									The character used to quote fields.
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>delimiter</code>
+								</td>
+								<td>
+									The delimiting character. It must not be found in <a href="#readonly">Papa.BAD_DELIMITERS</a>.
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>header</code>
+								</td>
+								<td>
+									If <code>false</code>, will omit the header row. If <code>data</code> is an array of arrays this option is ignored. If <code>data</code> is an array of objects the keys of the first object are the header row. If <code>data</code> is an object with the keys <code>fields</code> and <code>data</code> the <code>fields</code> are the header row.
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>newline</code>
+								</td>
+								<td>
+									The newline sequence. Must be one of <code>"\r"</code>, <code>"\n"</code>, or <code>"\r\n"</code>.
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>skipEmptyLines</code>
+								</td>
+								<td>
+									If <code>true</code>, lines that are completely empty (those which evaluate to an empty string) will be skipped. If set to <code>'greedy'</code>, lines that don't have any content (those which have only whitespace after parsing) will also be skipped.
+								</td>
+							</tr>
+						</table>
 					</div>
 					<div class="clear"></div>
 


### PR DESCRIPTION
This adds a dedicated section/block for the unparse config option.
I think this way it is more similar to the parse config.

It also clarifies some unparse options (e.g. `quotes` can be an array of booleans).