### PR TITLE
Fixes issue #609

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -261,7 +261,8 @@
 	delimiter: ",",
 	header: true,
 	newline: "\r\n",
-	skipEmptyLines: false, //or 'greedy'
+	skipEmptyLines: false, //or 'greedy',
+	columns: null //or array of strings
 }
 					</code></pre>
 				</div>
@@ -322,6 +323,14 @@
 								</td>
 								<td>
 									If <code>true</code>, lines that are completely empty (those which evaluate to an empty string) will be skipped. If set to <code>'greedy'</code>, lines that don't have any content (those which have only whitespace after parsing) will also be skipped.
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>columns</code>
+								</td>
+								<td>
+									If <code>data</code> is an array of objects this option can be used to manually specify the keys (columns) you expect in the objects. If not set the keys of the first objects are used as column.
 								</td>
 							</tr>
 						</table>

--- a/papaparse.js
+++ b/papaparse.js
@@ -291,10 +291,7 @@ License: MIT
 			if (!_input.length || Array.isArray(_input[0]))
 				return serialize(null, _input, _skipEmptyLines);
 			else if (typeof _input[0] === 'object')
-				return serialize(
-					_columns ? _columns : objectKeys(_input[0]),
-					_input, _skipEmptyLines
-				);
+				return serialize(_columns || objectKeys(_input[0]), _input, _skipEmptyLines);
 		}
 		else if (typeof _input === 'object')
 		{
@@ -351,6 +348,9 @@ License: MIT
 				_writeHeader = _config.header;
 
 			if (Array.isArray(_config.columns)) {
+
+				if (_config.columns.length === 0) throw new Error('Option columns was empty');
+
 				_columns = _config.columns;
 			}
 		}

--- a/papaparse.js
+++ b/papaparse.js
@@ -349,7 +349,7 @@ License: MIT
 
 			if (Array.isArray(_config.columns)) {
 
-				if (_config.columns.length === 0) throw new Error('Option columns was empty');
+				if (_config.columns.length === 0) throw new Error('Option columns is empty');
 
 				_columns = _config.columns;
 			}

--- a/papaparse.js
+++ b/papaparse.js
@@ -276,6 +276,9 @@ License: MIT
 		/** whether to skip empty lines */
 		var _skipEmptyLines = false;
 
+		/** the columns (keys) we expect when we unparse objects */
+		var _columns = null;
+
 		unpackConfig();
 
 		var quoteCharRegex = new RegExp(escapeRegExp(_quoteChar), 'g');
@@ -288,7 +291,10 @@ License: MIT
 			if (!_input.length || Array.isArray(_input[0]))
 				return serialize(null, _input, _skipEmptyLines);
 			else if (typeof _input[0] === 'object')
-				return serialize(objectKeys(_input[0]), _input, _skipEmptyLines);
+				return serialize(
+					_columns ? _columns : objectKeys(_input[0]),
+					_input, _skipEmptyLines
+				);
 		}
 		else if (typeof _input === 'object')
 		{
@@ -343,6 +349,10 @@ License: MIT
 
 			if (typeof _config.header === 'boolean')
 				_writeHeader = _config.header;
+
+			if (Array.isArray(_config.columns)) {
+				_columns = _config.columns;
+			}
 		}
 
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1739,13 +1739,6 @@ var UNPARSE_TESTS = [
 		input: [{a: 1, b: '2'}, {}, {a: 3, d: 'd', c: 4,}],
 		config: {columns: ['a', 'b', 'c']},
 		expected: 'a,b,c\r\n1,2,\r\n\r\n3,,4'
-	},
-	{
-		description: "Column option is empty",
-		notes: "Columns is empty so no data can be generated",
-		input: [{a: 1, b: '2'}, {}, {a: 3, d: 'd', c: 4,}],
-		config: {columns: []},
-		expectsError: true
 	}
 ];
 
@@ -1753,14 +1746,6 @@ describe('Unparse Tests', function() {
 	function generateTest(test) {
 		(test.disabled ? it.skip : it)(test.description, function() {
 			var actual;
-
-			if (test.expectsError) {
-				assert.throws(function() {
-					Papa.unparse(test.input, test.config);
-				});
-
-				return;
-			}
 
 			try {
 				actual = Papa.unparse(test.input, test.config);

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1732,6 +1732,20 @@ var UNPARSE_TESTS = [
 		input: [{a: null, b: ' '}, {}, {a: '1', b: '2'}],
 		config: {skipEmptyLines: 'greedy', header: true},
 		expected: 'a,b\r\n1,2'
+	},
+	{
+		description: "Column option used to manually specify keys",
+		notes: "Should not throw any error when attempting to serialize key not present in object. Columns are different than keys of the first object. When an object is missing a key then the serialized value should be an empty string.",
+		input: [{a: 1, b: '2'}, {}, {a: 3, d: 'd', c: 4,}],
+		config: {columns: ['a', 'b', 'c']},
+		expected: 'a,b,c\r\n1,2,\r\n\r\n3,,4'
+	},
+	{
+		description: "Column option is empty",
+		notes: "Header (columns) is empty so header is skipped",
+		input: [{a: 1, b: '2'}, {}, {a: 3, d: 'd', c: 4,}],
+		config: {columns: []},
+		expected: '\r\n\r\n'
 	}
 ];
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1742,10 +1742,10 @@ var UNPARSE_TESTS = [
 	},
 	{
 		description: "Column option is empty",
-		notes: "Header (columns) is empty so header is skipped",
+		notes: "Columns is empty so no data can be generated",
 		input: [{a: 1, b: '2'}, {}, {a: 3, d: 'd', c: 4,}],
 		config: {columns: []},
-		expected: '\r\n\r\n'
+		expectsError: true
 	}
 ];
 
@@ -1753,6 +1753,14 @@ describe('Unparse Tests', function() {
 	function generateTest(test) {
 		(test.disabled ? it.skip : it)(test.description, function() {
 			var actual;
+
+			if (test.expectsError) {
+				assert.throws(function() {
+					Papa.unparse(test.input, test.config);
+				});
+
+				return;
+			}
 
 			try {
 				actual = Papa.unparse(test.input, test.config);


### PR DESCRIPTION
Introduces a new `unparse` option `columns` to specify the columns/keys manually.

Some points i'm not sure about:

- Default value is currently null 
I think `[]` is not a good choice because then we need to check `_columns.length > 0` in order to know if the user specified a custom value. If someone des a `array.map()` for the keys that results into `[]` then the keys of the first object are used (which is unexpected).
However, maybe `null` looks a bit strange as default value

- I'm not sure about the last test... is the expected value correct?