### PR TITLE
Fix invalid link to lovers.js

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -196,7 +196,7 @@ Papa.parse(bigFile, {
 
 						<div class="grid-100 text-center">
 							<br>
-							<b><a href="https://github.com/mholt/PapaParse/blob/gh-pages/resources/js/lovers.js" class="add-lover-link subheader"><i class="fa fa-plus-square"></i> Add your link (it's free)</a></b>
+							<b><a href="https://github.com/mholt/PapaParse/blob/master/docs/resources/js/lovers.js" class="add-lover-link subheader"><i class="fa fa-plus-square"></i> Add your link (it's free)</a></b>
 						</div>
 					</div>
 				</section>


### PR DESCRIPTION
https://www.papaparse.com/ currently has 404 link to lovers.js, let's fix it.