### PR TITLE
#727 fix stale indexes used in whitespace tests during quote parsing.

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1536,6 +1536,12 @@ License: MIT
 							continue;
 						}
 
+						if(nextDelim !== -1 && nextDelim < (quoteSearch + 1)) {
+							nextDelim = input.indexOf(delim, (quoteSearch + 1));
+						}
+						if(nextNewline !== -1 && nextNewline < (quoteSearch + 1)) {
+							nextNewline = input.indexOf(newline, (quoteSearch + 1));
+						}
 						// Check up to nextDelim or nextNewline, whichever is closest
 						var checkUpTo = nextNewline === -1 ? nextDelim : Math.min(nextDelim, nextNewline);
 						var spacesBetweenQuoteAndDelimiter = extraSpaces(checkUpTo);

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1464,6 +1464,22 @@ var PARSE_TESTS = [
 			data: [['a', 'b'], ['c', 'd'], [' , ', ','], ['" "', '""']],
 			errors: []
 		}
+	},
+	{
+		description: "Quoted fields with spaces between closing quote and next delimiter and contains delimiter",
+		input: 'A,",B" ,C,D\nE,F,G,H',
+		expected: {
+			data: [['A', ',B', 'C', 'D'],['E', 'F', 'G', 'H']],
+			errors: []
+		}
+	},
+	{
+		description: "Quoted fields with spaces between closing quote and newline and contains newline",
+		input: 'a,b,"c\n" \nd,e,f',
+		expected: {
+			data: [['a', 'b', 'c\n'], ['d', 'e', 'f']],
+			errors: []
+		}
 	}
 ];
 


### PR DESCRIPTION
update delimiter and newline index if they are earlier than the current position before tested.