### PR TITLE
Strict quoting flag

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1393,6 +1393,8 @@ License: MIT
 		var step = config.step;
 		var preview = config.preview;
 		var fastMode = config.fastMode;
+		var _strictQuote = config.strictQuote;
+		var strictQuote = _strictQuote === undefined ? false : Boolean(_strictQuote);
 		var quoteChar;
 		/** Allows for no quoteChar by setting quoteChar to undefined in config */
 		if (config.quoteChar === undefined) {
@@ -1484,6 +1486,9 @@ License: MIT
 			var nextNewline = input.indexOf(newline, cursor);
 			var quoteCharRegex = new RegExp(escapeRegExp(escapeChar) + escapeRegExp(quoteChar), 'g');
 			var quoteSearch = input.indexOf(quoteChar, cursor);
+			var savedNextDelim;
+			var savedNextNewline;
+			var savedQuoteSearch;
 
 			// Parser loop
 			for (;;)
@@ -1491,11 +1496,11 @@ License: MIT
 				// Field has opening quote
 				if (input[cursor] === quoteChar)
 				{
+					var quoteFallThrough = false;
+					quoteSaveState();
+
 					// Start our search for the closing quote where the cursor is
 					quoteSearch = cursor;
-
-					// Skip the opening quote
-					cursor++;
 
 					for (;;)
 					{
@@ -1505,6 +1510,18 @@ License: MIT
 						//No other quotes are found - no other delimiters
 						if (quoteSearch === -1)
 						{
+							if(strictQuote) {
+								errors.push({
+									type: 'Quotes',
+									code: 'MissingQuotes',
+									message: 'Quoted field unterminated',
+									row: data.length,	// row has yet to be inserted
+									index: cursor
+								});
+								quoteRestoreState();
+								quoteFallThrough = true;
+								break; // fall through to parse as non-quote.
+							}
 							if (!ignoreLastRow) {
 								// No closing quote... what a pity
 								errors.push({
@@ -1515,13 +1532,13 @@ License: MIT
 									index: cursor
 								});
 							}
-							return finish();
+							return finish(input.substring(cursor + 1));
 						}
 
 						// Closing quote at EOF
 						if (quoteSearch === inputLen - 1)
 						{
-							var value = input.substring(cursor, quoteSearch).replace(quoteCharRegex, quoteChar);
+							var value = input.substring(cursor + 1, quoteSearch).replace(quoteCharRegex, quoteChar);
 							return finish(value);
 						}
 
@@ -1552,7 +1569,7 @@ License: MIT
 						// Closing quote followed by delimiter or 'unnecessary spaces + delimiter'
 						if (input[quoteSearch + 1 + spacesBetweenQuoteAndDelimiter] === delim)
 						{
-							row.push(input.substring(cursor, quoteSearch).replace(quoteCharRegex, quoteChar));
+							row.push(input.substring(cursor + 1, quoteSearch).replace(quoteCharRegex, quoteChar));
 							cursor = quoteSearch + 1 + spacesBetweenQuoteAndDelimiter + delimLen;
 
 							// If char after following delimiter is not quoteChar, we find next quote char position
@@ -1570,7 +1587,7 @@ License: MIT
 						// Closing quote followed by newline or 'unnecessary spaces + newLine'
 						if (input.substring(quoteSearch + 1 + spacesBetweenQuoteAndNewLine, quoteSearch + 1 + spacesBetweenQuoteAndNewLine + newlineLen) === newline)
 						{
-							row.push(input.substring(cursor, quoteSearch).replace(quoteCharRegex, quoteChar));
+							row.push(input.substring(cursor + 1, quoteSearch).replace(quoteCharRegex, quoteChar));
 							saveRow(quoteSearch + 1 + spacesBetweenQuoteAndNewLine + newlineLen);
 							nextDelim = input.indexOf(delim, cursor);	// because we may have skipped the nextDelim in the quoted field
 							quoteSearch = input.indexOf(quoteChar, cursor);	// we search for first quote in next line
@@ -1598,12 +1615,18 @@ License: MIT
 							index: cursor
 						});
 
+						if(strictQuote) {
+							quoteRestoreState();
+							quoteFallThrough = true;
+							break; // fall through to parse as non-quote.
+						}
 						quoteSearch++;
 						continue;
 
 					}
-
-					continue;
+					if(!quoteFallThrough) {
+						continue;
+					}
 				}
 
 				// Comment found at start of new line
@@ -1778,6 +1801,18 @@ License: MIT
 				}
 
 				return result;
+			}
+
+			function quoteSaveState() {
+				savedNextDelim = nextDelim;
+				savedNextNewline = nextNewline;
+				savedQuoteSearch = quoteSearch;
+			}
+
+			function quoteRestoreState() {
+				quoteSearch = savedQuoteSearch;
+				nextNewline = savedNextNewline;
+				nextDelim = savedNextDelim;
 			}
 		};
 

--- a/papaparse.js
+++ b/papaparse.js
@@ -1364,12 +1364,15 @@ License: MIT
 
 		function addError(type, code, msg, row)
 		{
-			_results.errors.push({
+			var error = {
 				type: type,
 				code: code,
-				message: msg,
-				row: row
-			});
+				message: msg
+			};
+			if(row !== undefined) {
+				error.row = row;
+			}
+			_results.errors.push(error);
 		}
 	}
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -616,8 +616,7 @@ var CORE_PARSER_TESTS = [
 				"index": 2
 			}]
 		}
-	},
-
+	}
 ];
 
 describe('Core Parser Tests', function() {

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -194,7 +194,7 @@ var CORE_PARSER_TESTS = [
 				"code": "MissingQuotes",
 				"message": "Quoted field unterminated",
 				"row": 0,
-				"index": 3
+				"index": 2
 			}]
 		}
 	},
@@ -209,7 +209,7 @@ var CORE_PARSER_TESTS = [
 				"code": "InvalidQuotes",
 				"message": "Trailing quote on quoted field is malformed",
 				"row": 0,
-				"index": 1
+				"index": 0
 			}]
 		}
 	},
@@ -224,14 +224,14 @@ var CORE_PARSER_TESTS = [
 				"code": "InvalidQuotes",
 				"message": "Trailing quote on quoted field is malformed",
 				"row": 0,
-				"index": 3
+				"index": 2
 			},
 			{
 				"type": "Quotes",
 				"code": "MissingQuotes",
 				"message": "Quoted field unterminated",
 				"row": 0,
-				"index": 3
+				"index": 2
 			}]
 		}
 	},
@@ -246,14 +246,14 @@ var CORE_PARSER_TESTS = [
 				"code": "InvalidQuotes",
 				"message": "Trailing quote on quoted field is malformed",
 				"row": 0,
-				"index": 3
+				"index": 2
 			},
 			{
 				"type": "Quotes",
 				"code": "MissingQuotes",
 				"message": "Quoted field unterminated",
 				"row": 0,
-				"index": 3
+				"index": 2
 			}]
 		}
 	},
@@ -268,14 +268,14 @@ var CORE_PARSER_TESTS = [
 				"code": "InvalidQuotes",
 				"message": "Trailing quote on quoted field is malformed",
 				"row": 0,
-				"index": 3
+				"index": 2
 			},
 			{
 				"type": "Quotes",
 				"code": "MissingQuotes",
 				"message": "Quoted field unterminated",
 				"row": 0,
-				"index": 3
+				"index": 2
 			}]
 		}
 	},
@@ -585,7 +585,55 @@ var CORE_PARSER_TESTS = [
 			data: [['a', 'b', 'c'], ['']],
 			errors: []
 		}
-	}
+	},
+	{
+		description: "Quoted field has invalid trailing quote after delimiter with a valid closer",
+		input: '"a,"b,c"\nd,e,f',
+		notes: "The input is malformed, opening quotes identified, trailing quote is malformed. Trailing quote should be escaped or followed by valid new line or delimiter to be valid",
+		config: { strictQuote: true },
+		expected: {
+			data: [['"a','b,c'], ['d', 'e', 'f']],
+			errors: [{
+				"type": "Quotes",
+				"code": "InvalidQuotes",
+				"message": "Trailing quote on quoted field is malformed",
+				"row": 0,
+				"index": 0
+			}]
+		}
+	},
+	{
+		description: "Quoted field has invalid trailing quote after delimiter with a valid closer in strict quote mode",
+		input: '"a,"b,c"\nd,e,f',
+		notes: "The input is malformed, opening quotes identified, trailing quote is malformed. Trailing quote should be escaped or followed by valid new line or delimiter to be valid",
+		config: { strictQuote: true },
+		expected: {
+			data: [['"a','b,c'], ['d', 'e', 'f']],
+			errors: [{
+				"type": "Quotes",
+				"code": "InvalidQuotes",
+				"message": "Trailing quote on quoted field is malformed",
+				"row": 0,
+				"index": 0
+			}]
+		}
+	},
+	{
+		description: "Quoted field has no closing quote in strict quote mode",
+		input: 'a,"b,c\nd,e,f',
+		config: { strictQuote: true },
+		expected: {
+			data: [['a','"b','c'],['d','e','f']],
+			errors: [{
+				"type": "Quotes",
+				"code": "MissingQuotes",
+				"message": "Quoted field unterminated",
+				"row": 0,
+				"index": 2
+			}]
+		}
+	},
+
 ];
 
 describe('Core Parser Tests', function() {

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -592,7 +592,7 @@ describe('Core Parser Tests', function() {
 	function generateTest(test) {
 		(test.disabled ? it.skip : it)(test.description, function() {
 			var actual = new Papa.Parser(test.config).parse(test.input);
-			assert.deepEqual(JSON.stringify(actual.errors), JSON.stringify(test.expected.errors));
+			assert.deepEqual(actual.errors, test.expected.errors);
 			assert.deepEqual(actual.data, test.expected.data);
 		});
 	}
@@ -1475,7 +1475,7 @@ describe('Parse Tests', function() {
 			if (test.expected.meta) {
 				assert.deepEqual(actual.meta, test.expected.meta);
 			}
-			assert.deepEqual(JSON.stringify(actual.errors), JSON.stringify(test.expected.errors));
+			assert.deepEqual(actual.errors, test.expected.errors);
 			assert.deepEqual(actual.data, test.expected.data);
 		});
 	}
@@ -1556,7 +1556,7 @@ describe('Parse Async Tests', function() {
 			var config = test.config;
 
 			config.complete = function(actual) {
-				assert.deepEqual(JSON.stringify(actual.errors), JSON.stringify(test.expected.errors));
+				assert.deepEqual(actual.errors, test.expected.errors);
 				assert.deepEqual(actual.data, test.expected.data);
 				done();
 			};
@@ -2384,7 +2384,7 @@ describe('Custom Tests', function() {
 				this.timeout(test.timeout);
 			}
 			test.run(function(actual) {
-				assert.deepEqual(JSON.stringify(actual), JSON.stringify(test.expected));
+				assert.deepEqual(actual, test.expected);
 				done();
 			});
 		});

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -587,22 +587,6 @@ var CORE_PARSER_TESTS = [
 		}
 	},
 	{
-		description: "Quoted field has invalid trailing quote after delimiter with a valid closer",
-		input: '"a,"b,c"\nd,e,f',
-		notes: "The input is malformed, opening quotes identified, trailing quote is malformed. Trailing quote should be escaped or followed by valid new line or delimiter to be valid",
-		config: { strictQuote: true },
-		expected: {
-			data: [['"a','b,c'], ['d', 'e', 'f']],
-			errors: [{
-				"type": "Quotes",
-				"code": "InvalidQuotes",
-				"message": "Trailing quote on quoted field is malformed",
-				"row": 0,
-				"index": 0
-			}]
-		}
-	},
-	{
 		description: "Quoted field has invalid trailing quote after delimiter with a valid closer in strict quote mode",
 		input: '"a,"b,c"\nd,e,f',
 		notes: "The input is malformed, opening quotes identified, trailing quote is malformed. Trailing quote should be escaped or followed by valid new line or delimiter to be valid",


### PR DESCRIPTION
If a quoted field is not properly terminated then treat the field as an un-quoted field.
Fix: Adjust error reporting in quote handling to reference the index of the beginning of the field.