### PR TITLE
Using self instead of this to preserve binding.

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1115,7 +1115,7 @@ License: MIT
 			} else {
 				// Bugfix: #636 In case the processing hasn't halted yet
 				// wait for it to halt in order to resume
-				setTimeout(this.resume, 3);
+				setTimeout(self.resume, 3);
 			}
 		};
 


### PR DESCRIPTION
This should be `self.resume` instead of `this.resume` as `this` refers to the `window` object when the callback occurs. Meaning, it would fail to do the next recursive call if the need arose.

Do you have any testing strategy in mind for such a thing? Do we need a test here?