### PR TITLE
Added feature to support POST method when download is true

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -433,6 +433,7 @@ var csv = Papa.unparse({
 	error: undefined,
 	download: false,
 	downloadRequestHeaders: undefined,
+	downloadRequestBody: undefined,
 	skipEmptyLines: false,
 	chunk: undefined,
 	fastMode: undefined,
@@ -597,6 +598,14 @@ var csv = Papa.unparse({
 'Authorization': 'token 123345678901234567890',
 }</code>
 									</pre>
+							</tr>
+							<tr>
+								<td>
+									<code>downloadRequestBody</code>
+								</td>
+								<td>
+									If defined and the download property is true, a POST request will be made instead of a GET request and the passed argument will be set as the body of the request.
+								</td>
 							</tr>
 							<tr>
 								<td>

--- a/papaparse.js
+++ b/papaparse.js
@@ -642,7 +642,7 @@ License: MIT
 				xhr.onerror = bindFunction(this._chunkError, this);
 			}
 
-			xhr.open('GET', this._input, !IS_WORKER);
+			xhr.open(this._config.downloadRequestBody ? 'POST' : 'GET', this._input, !IS_WORKER);
 			// Headers can only be set when once the request state is OPENED
 			if (this._config.downloadRequestHeaders)
 			{
@@ -661,7 +661,7 @@ License: MIT
 			}
 
 			try {
-				xhr.send();
+				xhr.send(this._config.downloadRequestBody);
 			}
 			catch (err) {
 				this._chunkError(err.message);


### PR DESCRIPTION
Hi awesome library and first time to contribute to any github project.

I just wanted to  share a little bit of code change to support POST method when the download property of config is true. 

I wanted to share a solution to a problem related to mine in stackoverflow(https://stackoverflow.com/questions/55841129/how-to-using-post-method-to-download-csv-file-using-papaparse) as well as issue #657 

Sorry I did not create any test case for this as I didn't know how I can test a POST method using the available packages, but if you have an advice on how to do it I'll gladly learn it and create one.