### PR TITLE
Add further check to guessDelimiter if its better (#804)

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1335,7 +1335,7 @@ License: MIT
 					avgFieldCount /= (preview.data.length - emptyLinesCount);
 
 				if ((typeof bestDelta === 'undefined' || delta <= bestDelta)
-					&& (typeof maxFieldCount === 'undefined' || avgFieldCount > maxFieldCount) && avgFieldCount > 1.99) {
+					&& ((typeof maxFieldCount === 'undefined' || avgFieldCount > maxFieldCount) || delta < bestDelta) && avgFieldCount > 1.99) {
 					bestDelta = delta;
 					bestDelim = delim;
 					maxFieldCount = avgFieldCount;

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -4,7 +4,7 @@ if (typeof module !== 'undefined' && module.exports) {
 	chai = require('chai');
 	Papa = require('../papaparse.js');
 }
-var fs = require('fs');
+
 var assert = chai.assert;
 
 var BASE_PATH = (typeof document === 'undefined') ? './' : document.getElementById('test-cases').src.replace(/test-cases\.js$/, '');
@@ -2538,15 +2538,7 @@ var CUSTOM_TESTS = [
 			var results = Papa.parse('"A","B","C","D"');
 			callback(results.meta.delimiter);
 		}
-  },
-  {
-    description: "Should correctly guess default delimiters when other sign is used more often but not right delimiter.",
-    expected: ";",
-    run: function(callback) {            
-      var results = Papa.parse('ID;comment;geom\n1;HiThere;POLYGON(2 3, 3 4, 5 6, 4 5, 4 3, 2 3)\n2;HowAreYou;POLYGON(2 3, 3 4, 5 6, 4 5, 4 3, 2 3)\n3;WhatsUp;POLYGON(2 3, 3 4, 5 6, 4 5, 4 3, 2 3)\n4;Sunday;POLYGON(2 3, 3 4, 5 6, 4 5, 4 3, 2 3)');     
-      callback(results.meta.delimiter)
-    }
-  }
+	}
 ];
 
 describe('Custom Tests', function() {

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -4,7 +4,7 @@ if (typeof module !== 'undefined' && module.exports) {
 	chai = require('chai');
 	Papa = require('../papaparse.js');
 }
-
+var fs = require('fs');
 var assert = chai.assert;
 
 var BASE_PATH = (typeof document === 'undefined') ? './' : document.getElementById('test-cases').src.replace(/test-cases\.js$/, '');
@@ -2538,7 +2538,15 @@ var CUSTOM_TESTS = [
 			var results = Papa.parse('"A","B","C","D"');
 			callback(results.meta.delimiter);
 		}
-	}
+  },
+  {
+    description: "Should correctly guess default delimiters when other sign is used more often but not right delimiter.",
+    expected: ";",
+    run: function(callback) {            
+      var results = Papa.parse('ID;comment;geom\n1;HiThere;POLYGON(2 3, 3 4, 5 6, 4 5, 4 3, 2 3)\n2;HowAreYou;POLYGON(2 3, 3 4, 5 6, 4 5, 4 3, 2 3)\n3;WhatsUp;POLYGON(2 3, 3 4, 5 6, 4 5, 4 3, 2 3)\n4;Sunday;POLYGON(2 3, 3 4, 5 6, 4 5, 4 3, 2 3)');     
+      callback(results.meta.delimiter)
+    }
+  }
 ];
 
 describe('Custom Tests', function() {

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -2538,7 +2538,15 @@ var CUSTOM_TESTS = [
 			var results = Papa.parse('"A","B","C","D"');
 			callback(results.meta.delimiter);
 		}
-	}
+  },
+  {
+    description: "Should correctly guess default delimiters when other sign is used more often but not right delimiter.",
+    expected: ";",
+    run: function(callback) {
+      var results = Papa.parse('ID;comment;geom\n1;HiThere;POLYGON(2 3, 3 4, 5 6, 4 5, 4 3, 2 3)\n2;HowAreYou;POLYGON(2 3, 3 4, 5 6, 4 5, 4 3, 2 3)\n3;WhatsUp;POLYGON(2 3, 3 4, 5 6, 4 5, 4 3, 2 3)\n4;Sunday;POLYGON(2 3, 3 4, 5 6, 4 5, 4 3, 2 3)');
+      callback(results.meta.delimiter);
+    }
+  }
 ];
 
 describe('Custom Tests', function() {


### PR DESCRIPTION
In guessDelimiter()-function when checking if delimiter might be better, I added the check `delta < bestDelta` in case of avgFieldCount isn't bigger than maxFieldCount. Therefore I also added a test case to verify.

In my opinion you can say that if delta is smaller than bestDelta the delimiter is more appropriate even if avgFieldCount is smaller than maxFieldCount in case avgFieldCount is bigger than 1.99. I had a file where it guessed comma instead of semicolon, see #804. 
The reason for this was that in this file there are more commas than semicolons, so the avgFieldCount was higher for comma than for semicolon although the delta was zero for semicolon but four for comma.