### PR TITLE
Add index argument to "transformHeader" config function

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1189,10 +1189,10 @@ License: MIT
 			if (!_results)
 				return;
 
-			function addHeder(header)
+			function addHeader(header, i)
 			{
 				if (isFunction(_config.transformHeader))
-					header = _config.transformHeader(header);
+					header = _config.transformHeader(header, i);
 
 				_fields.push(header);
 			}
@@ -1200,13 +1200,13 @@ License: MIT
 			if (Array.isArray(_results.data[0]))
 			{
 				for (var i = 0; needsHeaderRow() && i < _results.data.length; i++)
-					_results.data[i].forEach(addHeder);
+					_results.data[i].forEach(addHeader);
 
 				_results.data.splice(0, 1);
 			}
 			// if _results.data[0] is not an array, we are in a step where _results.data is the row.
 			else
-				_results.data.forEach(addHeder);
+				_results.data.forEach(addHeader);
 		}
 
 		function shouldApplyDynamicTyping(field) {


### PR DESCRIPTION
When transforming headers, knowing what column index a header refers to can be extremely useful.

This PR adds the header index as an optional second argument to the `transformHeader` config function.

This PR also corrects the `addHeder` typo (changed to `addHeader`).

Cheers!

🤓👍
