### PR TITLE
added check for property own to ignore prototype chain

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -376,8 +376,11 @@ License: MIT
 			if (typeof obj !== 'object')
 				return [];
 			var keys = [];
-			for (var key in obj)
-				keys.push(key);
+			for (var key in obj) {
+				if (Object.prototype.hasOwnProperty.call(obj, key)) {
+					keys.push(key);
+				}
+			}
 			return keys;
 		}
 


### PR DESCRIPTION
I'm using library (method `unparse` to generate csv) with objects which made from class with static property (using babel). Because of using `for..in` loop in `objectKeys` all methods from prototype chain contained in generated CSV (function methods etc.).
To prevent this i added check for own properties.
This behavior mentioned in  #303 