### PR TITLE
Added option quoteDataWithSpaces (default - true) to unparse config.

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -285,6 +285,9 @@ License: MIT
 		/** whether to prevent outputting cells that can be parsed as formulae by spreadsheet software (Excel and LibreOffice) */
 		var _escapeFormulae = false;
 
+		/** whether to surround every datum that has spaces in the start or in the end with quotes */
+		var _quoteDataWithSpaces = true;
+
 		unpackConfig();
 
 		var quoteCharRegex = new RegExp(escapeRegExp(_quoteChar), 'g');
@@ -367,6 +370,9 @@ License: MIT
 
 			if (typeof _config.escapeFormulae === 'boolean')
 				_escapeFormulae = _config.escapeFormulae;
+
+			if (typeof _config.quoteDataWithSpaces === 'boolean')
+				_quoteDataWithSpaces = _config.quoteDataWithSpaces;
 		}
 
 
@@ -464,8 +470,8 @@ License: MIT
 							|| (Array.isArray(_quotes) && _quotes[col])
 							|| hasAny(escapedQuoteStr, Papa.BAD_DELIMITERS)
 							|| escapedQuoteStr.indexOf(_delimiter) > -1
-							|| escapedQuoteStr.charAt(0) === ' '
-							|| escapedQuoteStr.charAt(escapedQuoteStr.length - 1) === ' ';
+							|| (_quoteDataWithSpaces && escapedQuoteStr.charAt(0) === ' ')
+							|| (_quoteDataWithSpaces && escapedQuoteStr.charAt(escapedQuoteStr.length - 1) === ' ');
 
 			return needsQuotes ? _quoteChar + escapedQuoteStr + _quoteChar : escapedQuoteStr;
 		}


### PR DESCRIPTION
If quoteDataWithSpaces set to false, unparse result doesn't quote data with spaces in the start or in the end.