### PR TITLE
Fix #866 - Multi-character delimiter with quoted field issue

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -303,7 +303,7 @@
 									<code>delimiter</code>
 								</td>
 								<td>
-									The delimiting character. It must not be found in <a href="#readonly">Papa.BAD_DELIMITERS</a>.
+									The delimiting character. Multi-character delimiters are supported. It must not be found in <a href="#readonly">Papa.BAD_DELIMITERS</a>.
 								</td>
 							</tr>
 							<tr>
@@ -470,7 +470,7 @@ var csv = Papa.unparse({
 									<code>delimiter</code>
 								</td>
 								<td>
-									The delimiting character. Leave blank to auto-detect from a list of most common delimiters, or any values passed in through <code>delimitersToGuess</code>. It can be a string or a function. If string, it must be one of length 1. If a function, it must accept the input as first parameter and it must return a string which will be used as delimiter. In both cases it cannot be found in <a href="#readonly">Papa.BAD_DELIMITERS</a>.
+									The delimiting character. Leave blank to auto-detect from a list of most common delimiters, or any values passed in through <code>delimitersToGuess</code>. It can be a string or a function. If a string, it can be of any length (so multi-character delimiters are supported). If a function, it must accept the input as first parameter and it must return a string which will be used as delimiter. In both cases it cannot be found in <a href="#readonly">Papa.BAD_DELIMITERS</a>.
 								</td>
 							</tr>
 							<tr>
@@ -861,7 +861,7 @@ var csv = Papa.unparse({
 							<tr>
 								<td><code>Papa.BAD_DELIMITERS</code></td>
 								<td>
-									An array of characters that are not allowed as delimiters.
+									An array of characters that are not allowed as delimiters (<code>\r, \n, ", \ufeff</code>).
 								</td>
 							</tr>
 							<tr>

--- a/papaparse.js
+++ b/papaparse.js
@@ -1555,7 +1555,7 @@ License: MIT
 						var spacesBetweenQuoteAndDelimiter = extraSpaces(checkUpTo);
 
 						// Closing quote followed by delimiter or 'unnecessary spaces + delimiter'
-						if (input[quoteSearch + 1 + spacesBetweenQuoteAndDelimiter] === delim)
+						if (input.substr(quoteSearch + 1 + spacesBetweenQuoteAndDelimiter, delimLen) === delim)
 						{
 							row.push(input.substring(cursor, quoteSearch).replace(quoteCharRegex, quoteChar));
 							cursor = quoteSearch + 1 + spacesBetweenQuoteAndDelimiter + delimLen;

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -848,6 +848,16 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Multi-character delimiter (length 2) with quoted field",
+		input: 'a, b, "c, e", d',
+		config: { delimiter: ", " },
+		notes: "The quotes must be immediately adjacent to the delimiter to indicate a quoted field",
+		expected: {
+			data: [['a', 'b', 'c, e', 'd']],
+			errors: []
+		}
+	},
+	{
 		description: "Callback delimiter",
 		input: 'a$ b$ c',
 		config: { delimiter: function(input) { return input[1] + ' '; } },
@@ -1712,6 +1722,12 @@ var UNPARSE_TESTS = [
 		input: [['A', 'b', 'c'], ['d', 'e', 'f']],
 		config: { delimiter: ', ' },
 		expected: 'A, b, c\r\nd, e, f'
+	},
+	{
+		description: "Custom delimiter (Multi-character), field contains custom delimiter",
+		input: [['A', 'b', 'c'], ['d', 'e', 'f, g']],
+		config: { delimiter: ', ' },
+		expected: 'A, b, c\r\nd, e, "f, g"'
 	},
 	{
 		description: "Bad delimiter (\\n)",


### PR DESCRIPTION
Fixes issue #866. I've also added some test for unparsing multi character delimiter where a field contains the delimiter (and needs to be quoted)