### PR TITLE
Fix for issue #911

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1163,9 +1163,9 @@ License: MIT
 
 			if (_config.skipEmptyLines)
 			{
-				for (var i = 0; i < _results.data.length; i++)
-					if (testEmptyLine(_results.data[i]))
-						_results.data.splice(i--, 1);
+				_results.data = _results.data.filter(function(d) {
+					return !testEmptyLine(d);
+				});
 			}
 
 			if (needsHeaderRow())

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1608,6 +1608,31 @@ var PARSE_ASYNC_TESTS = [
 			data: [['A','B','C'],['X','Y','Z']],
 			errors: []
 		}
+	},
+	{
+		description: "File with a few regular and lots of empty lines",
+		disabled: !FILES_ENABLED,
+		input: FILES_ENABLED ? new File(["A,B,C\nX,Y,Z\n" + new Array(500000).fill(",,").join("\n")], "sample.csv") : false,
+		config: {
+			skipEmptyLines: "greedy"
+		},
+		expected: {
+			data: [['A','B','C'],['X','Y','Z']],
+			errors: []
+		}
+	},
+	{
+		description: "File with a few regular and lots of empty lines + worker",
+		disabled: !FILES_ENABLED,
+		input: FILES_ENABLED ? new File(["A,B,C\nX,Y,Z\n" + new Array(500000).fill(",,").join("\n")], "sample.csv") : false,
+		config: {
+			worker: true,
+			skipEmptyLines: "greedy"
+		},
+		expected: {
+			data: [['A','B','C'],['X','Y','Z']],
+			errors: []
+		}
 	}
 ];
 
@@ -1836,9 +1861,9 @@ var UNPARSE_TESTS = [
 	},
 	{
 		description: "Returns without rows with no content when skipEmptyLines is 'greedy'",
-		input: [[null, ' '], [], ['1', '2']],
+		input: [[null, ' '], [], ['1', '2']].concat(new Array(500000).fill(['', ''])).concat([['3', '4']]),
 		config: {skipEmptyLines: 'greedy'},
-		expected: '1,2'
+		expected: '1,2\r\n3,4'
 	},
 	{
 		description: "Returns empty rows when empty rows are passed and skipEmptyLines is false with headers",


### PR DESCRIPTION
This change should address the performance issue [#911](https://github.com/mholt/PapaParse/issues/911) where parsing a file with a lot of empty rows takes more time than expected when `skipEmptyLines` option is set to `greedy`.