### PR TITLE
fix: set empty string to config.quotechar when it's value is null

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1403,8 +1403,7 @@ License: MIT
 		var preview = config.preview;
 		var fastMode = config.fastMode;
 		var quoteChar;
-		/** Allows for no quoteChar by setting quoteChar to undefined in config */
-		if (config.quoteChar === undefined) {
+		if (config.quoteChar === undefined || config.quoteChar === null) {
 			quoteChar = '"';
 		} else {
 			quoteChar = config.quoteChar;


### PR DESCRIPTION
Closes #914