### PR TITLE
[GH-788] Made the check to determine whether the current web-worker is owned by PapaParse more reliable

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -49,11 +49,12 @@ License: MIT
 	function getWorkerBlob() {
 		var URL = global.URL || global.webkitURL || null;
 		var code = moduleFactory.toString();
-		return Papa.BLOB_URL || (Papa.BLOB_URL = URL.createObjectURL(new Blob(['(', code, ')();'], {type: 'text/javascript'})));
+		return Papa.BLOB_URL || (Papa.BLOB_URL = URL.createObjectURL(new Blob(["var global = (function() { if (typeof self !== 'undefined') { return self; } if (typeof window !== 'undefined') { return window; } if (typeof global !== 'undefined') { return global; } return {}; })(); global.IS_PAPA_WORKER=true; ", '(', code, ')();'], {type: 'text/javascript'})));
 	}
 
 	var IS_WORKER = !global.document && !!global.postMessage,
-		IS_PAPA_WORKER = IS_WORKER && /blob:/i.test((global.location || {}).protocol);
+		IS_PAPA_WORKER = global.IS_PAPA_WORKER || false;
+
 	var workers = {}, workerIdCounter = 0;
 
 	var Papa = {};

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
 	"extends": ["../.eslintrc.js"],
+	"parserOptions": {
+		"ecmaVersion": 8
+	},
 	"env": {
 		"mocha": true
 	},


### PR DESCRIPTION
This fixes #788

Previously, the assumption was if we're in a web-worker AND the worker was loaded from a blob, the worker *must* be ours.