### PR TITLE
Fix transformHeader can't work with worker (#623) (#761)

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -201,6 +201,7 @@ License: MIT
 
 		_config.transform = isFunction(_config.transform) ? _config.transform : false;
 
+
 		if (_config.worker && Papa.WORKERS_SUPPORTED)
 		{
 			var w = newWorker();
@@ -214,6 +215,10 @@ License: MIT
 			_config.chunk = isFunction(_config.chunk);
 			_config.complete = isFunction(_config.complete);
 			_config.error = isFunction(_config.error);
+			
+			if (isFunction(_config.transformHeader)) {
+				_config.transformHeader = _config.transformHeader.toString();
+			}
 			delete _config.worker;	// prevent infinite loop
 
 			w.postMessage({
@@ -1833,6 +1838,9 @@ License: MIT
 
 		if (typeof Papa.WORKER_ID === 'undefined' && msg)
 			Papa.WORKER_ID = msg.workerId;
+
+		if (typeof msg.config.transformHeader === "string") {
+			eval('msg.config.transformHeader = ' + msg.config.transformHeader);
 
 		if (typeof msg.input === 'string')
 		{


### PR DESCRIPTION
When worker set to true, convert transformHeader function to string, so the config could be cloned to worker and convert back in worker thread by `eval`.
So, when using Content Security Policy, this workaround will still fail, consider to use vkThread instead.