### PR TITLE
Fix for polluted Array

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1476,7 +1476,7 @@ License: MIT
 				var headerCount = {};
 				var duplicateHeaders = false;
 
-				for (var j in headers) {
+				for (var j = 0; j < headers.length; j++) {
 					var header = headers[j];
 					if (isFunction(config.transformHeader))
 						header = config.transformHeader(header, j);

--- a/papaparse.js
+++ b/papaparse.js
@@ -1476,6 +1476,7 @@ License: MIT
 				var headerCount = {};
 				var duplicateHeaders = false;
 
+				// Using old-style 'for' loop to avoid prototype pollution that would be picked up with 'var j in headers'
 				for (var j = 0; j < headers.length; j++) {
 					var header = headers[j];
 					if (isFunction(config.transformHeader))

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -2674,6 +2674,20 @@ var CUSTOM_TESTS = [
 			});
 		}
 	},
+	{
+		description: "Array prototype pollution does not break in header transformation",
+		expected: [{H0: 'a', H1: 'a'}, {H0: 'b', H1: 'b'}],
+		run: function(callback) {
+			Array.prototype.myHandyFunction = function() {};  // eslint-disable-line no-extend-native
+			Papa.parse('h0,h1\na,a\nb,b', {
+				header: true,
+				transformHeader: (value) => value.toUpperCase(), // Function that assumes a header value is a String
+				complete: function(actual) {
+					callback(actual.data);
+				}
+			});
+		}
+	},
 ];
 
 describe('Custom Tests', function() {

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -2674,20 +2674,6 @@ var CUSTOM_TESTS = [
 			});
 		}
 	},
-	{
-		description: "Array prototype pollution does not break in header transformation",
-		expected: [{H0: 'a', H1: 'a'}, {H0: 'b', H1: 'b'}],
-		run: function(callback) {
-			Array.prototype.myHandyFunction = function() {};  // eslint-disable-line no-extend-native
-			Papa.parse('h0,h1\na,a\nb,b', {
-				header: true,
-				transformHeader: (value) => value.toUpperCase(), // Function that assumes a header value is a String
-				complete: function(actual) {
-					callback(actual.data);
-				}
-			});
-		}
-	},
 ];
 
 describe('Custom Tests', function() {


### PR DESCRIPTION
We have some helper methods on our Array object.  Papaparse started blowing up with the latest update (seems to be from [this commit](https://github.com/mholt/PapaParse/commit/c1cbe16636be146f5f1d321cdd7cbddc9143b045)).

This bugfix updates the for loop to only interate over the array's elements, not the properties of the Array object.

Here's my testing sandbox, if you want to have a play: https://codesandbox.io/s/zealous-liskov-nuj41l?file=/src/index.js

I don't contribute to OSS often so this is quite new to me.  I'm happy to take any feedback on my pull.