### PR TITLE
feat: renamed headers meta

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -502,7 +502,8 @@ var csv = Papa.unparse({
 									<code>header</code>
 								</td>
 								<td>
-									If true, the first row of parsed data will be interpreted as field names. An array of field names will be returned in <a href="#meta">meta</a>, and each row of data will be an object of values keyed by field name instead of a simple array. Rows with a different number of fields from the header row will produce an error. Warning: Duplicate field names will overwrite values in previous fields having the same name.
+									If true, the first row of parsed data will be interpreted as field names. An array of field names will be returned in <a href="#meta">meta</a>, and each row of data will be an object of values keyed by field name instead of a simple array. Rows with a different number of fields from the header row will produce an error. 
+									Warning: Duplicated field names will be automatically renamed to avoid values in previous fields having the same name to be overwritten. Renamed fields with original (or transformed by <code>transformHeader</code>) are stored in <code>ParseResult.meta.renamedHeaders</code>
 								</td>
 							</tr>
 							<tr>
@@ -759,11 +760,13 @@ var csv = Papa.unparse({
 [
 	{
 		"Column 1": "foo",
-		"Column 2": "bar"
+		"Column 2": "bar",
+		"Column 1": "foo1",
 	},
 	{
 		"Column 1": "abc",
-		"Column 2": "def"
+		"Column 2": "def",
+		"Column 1": "abc1",
 	}
 ]</code></pre>
 					</div>
@@ -811,6 +814,7 @@ var csv = Papa.unparse({
 	aborted:   // Whether process was aborted
 	fields:    // Array of field names
 	truncated: // Whether preview consumed all input
+	renamedHeaders: // Headers that are automatically renamed by the library to avoid duplication. {Column 1_1: 'Column 1' // the later header 'Column 1' was renamed to 'Column 1_1'}
 }</code></pre>
 					</div>
 					<div class="grid-50">

--- a/papaparse.js
+++ b/papaparse.js
@@ -1413,6 +1413,8 @@ License: MIT
 		var preview = config.preview;
 		var fastMode = config.fastMode;
 		var quoteChar;
+		var renamedHeaders = null;
+
 		if (config.quoteChar === undefined || config.quoteChar === null) {
 			quoteChar = '"';
 		} else {
@@ -1475,7 +1477,6 @@ License: MIT
 				var headerMap = new Set();
 				var headerCount = {};
 				var duplicateHeaders = false;
-				var renamedHeaders = null;
 
 				for (var j in headers) {
 					var header = headers[j];
@@ -1777,7 +1778,8 @@ License: MIT
 						linebreak: newline,
 						aborted: aborted,
 						truncated: !!stopped,
-						cursor: lastCursor + (baseIndex || 0)
+						cursor: lastCursor + (baseIndex || 0),
+						renamedHeaders: renamedHeaders
 					}
 				};
 			}

--- a/papaparse.js
+++ b/papaparse.js
@@ -1413,6 +1413,7 @@ License: MIT
 		var preview = config.preview;
 		var fastMode = config.fastMode;
 		var quoteChar;
+		var renamedHeaders = null;
 		if (config.quoteChar === undefined || config.quoteChar === null) {
 			quoteChar = '"';
 		} else {
@@ -1469,32 +1470,36 @@ License: MIT
 			// Rename headers if there are duplicates
 			if (config.header && !baseIndex)
 			{
+				renamedHeaders = {};
 				var firstLine = input.split(newline)[0];
 				var headers = firstLine.split(delim);
 				var separator = '_';
 				var headerMap = new Set();
 				var headerCount = {};
-				var duplicateHeaders = false;
+				var duplicatedHeaders = false;
 
 				for (var j in headers) {
-					var header = headers[j];
+					var originalHeader = headers[j];
 					if (isFunction(config.transformHeader))
-						header = config.transformHeader(header, j);
-					var headerName = header;
+						var transformedHeader = config.transformHeader(originalHeader, j);
+					var headerName = transformedHeader;
 
-					var count = headerCount[header] || 0;
+					var count = headerCount[transformedHeader] || 0;
 					if (count > 0) {
-						duplicateHeaders = true;
-						headerName = header + separator + count;
+						duplicatedHeaders = true;
+						headerName = transformedHeader + separator + count;
 					}
-					headerCount[header] = count + 1;
+					headerCount[transformedHeader] = count + 1;
 					// In case it already exists, we add more separators
 					while (headerMap.has(headerName)) {
 						headerName = headerName + separator + count;
 					}
 					headerMap.add(headerName);
+					if (count > 0) {
+						renamedHeaders[headerName] = transformedHeader;
+					}
 				}
-				if (duplicateHeaders) {
+				if (duplicatedHeaders) {
 					var editedInput = input.split(newline);
 					editedInput[0] = Array.from(headerMap).join(delim);
 					input = editedInput.join(newline);
@@ -1769,7 +1774,8 @@ License: MIT
 						linebreak: newline,
 						aborted: aborted,
 						truncated: !!stopped,
-						cursor: lastCursor + (baseIndex || 0)
+						cursor: lastCursor + (baseIndex || 0),
+						renamedHeaders: renamedHeaders
 					}
 				};
 			}

--- a/papaparse.js
+++ b/papaparse.js
@@ -1413,7 +1413,6 @@ License: MIT
 		var preview = config.preview;
 		var fastMode = config.fastMode;
 		var quoteChar;
-		var renamedHeaders = null;
 		if (config.quoteChar === undefined || config.quoteChar === null) {
 			quoteChar = '"';
 		} else {
@@ -1470,36 +1469,40 @@ License: MIT
 			// Rename headers if there are duplicates
 			if (config.header && !baseIndex)
 			{
-				renamedHeaders = {};
 				var firstLine = input.split(newline)[0];
 				var headers = firstLine.split(delim);
 				var separator = '_';
 				var headerMap = new Set();
 				var headerCount = {};
-				var duplicatedHeaders = false;
+				var duplicateHeaders = false;
+				var renamedHeaders = null;
 
 				for (var j in headers) {
-					var originalHeader = headers[j];
+					var header = headers[j];
 					if (isFunction(config.transformHeader))
-						var transformedHeader = config.transformHeader(originalHeader, j);
-					var headerName = transformedHeader;
+						header = config.transformHeader(header, j);
+					var headerName = header;
 
-					var count = headerCount[transformedHeader] || 0;
+					var count = headerCount[header] || 0;
 					if (count > 0) {
-						duplicatedHeaders = true;
-						headerName = transformedHeader + separator + count;
+						duplicateHeaders = true;
+						headerName = header + separator + count;
+						// Initialise the variable if it hasn't been.
+						if (renamedHeaders === null) {
+							renamedHeaders = {};
+						}
 					}
-					headerCount[transformedHeader] = count + 1;
+					headerCount[header] = count + 1;
 					// In case it already exists, we add more separators
 					while (headerMap.has(headerName)) {
 						headerName = headerName + separator + count;
 					}
 					headerMap.add(headerName);
 					if (count > 0) {
-						renamedHeaders[headerName] = transformedHeader;
+						renamedHeaders[headerName] = header;
 					}
 				}
-				if (duplicatedHeaders) {
+				if (duplicateHeaders) {
 					var editedInput = input.split(newline);
 					editedInput[0] = Array.from(headerMap).join(delim);
 					input = editedInput.join(newline);
@@ -1774,8 +1777,7 @@ License: MIT
 						linebreak: newline,
 						aborted: aborted,
 						truncated: !!stopped,
-						cursor: lastCursor + (baseIndex || 0),
-						renamedHeaders: renamedHeaders
+						cursor: lastCursor + (baseIndex || 0)
 					}
 				};
 			}

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -32,6 +32,7 @@ function assertLongSampleParsedCorrectly(parsedCsv) {
 		"linebreak": "\n",
 		"aborted": false,
 		"truncated": false,
+		renamedHeaders: null,
 		"cursor": 1209
 	});
 	assert.equal(parsedCsv.errors.length, 0);

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -29,7 +29,8 @@ var CORE_PARSER_TESTS = [
 		input: 'A,b,c',
 		expected: {
 			data: [['A', 'b', 'c']],
-			errors: []
+			errors: [],
+			meta: {delimiter: ',', renamedHeaders: null}
 		}
 	},
 	{
@@ -587,30 +588,33 @@ var CORE_PARSER_TESTS = [
 		}
 	},
 	{
-		description: "Simple duplicate header names",
+		description: "Simple duplicated header names",
 		input: 'A,A,A,A\n1,2,3,4',
 		config: { header: true },
 		expected: {
 			data: [['A', 'A_1', 'A_2', 'A_3'], ['1', '2', '3', '4']],
-			errors: []
+			errors: [],
+			meta: {renamedHeaders: {A_1: 'A', A_2: 'A', A_3: 'A'}}
 		}
 	},
 	{
-		description: "Duplicate header names with headerTransform",
+		description: "Duplicated header names with headerTransform",
 		input: 'A,A,A,A\n1,2,3,4',
 		config: { header: true, transformHeader: function(header) { return header.toLowerCase(); } },
 		expected: {
 			data: [['a', 'a_1', 'a_2', 'a_3'], ['1', '2', '3', '4']],
-			errors: []
+			errors: [],
+			meta: {renamedHeaders: {a_1: 'a', a_2: 'a', a_3: 'a'}}
 		}
 	},
 	{
-		description: "Duplicate header names existing column",
+		description: "Duplicated header names existing column",
 		input: 'c,c,c,c_1\n1,2,3,4',
 		config: { header: true },
 		expected: {
 			data: [['c', 'c_1', 'c_2', 'c_1_0'], ['1', '2', '3', '4']],
-			errors: []
+			errors: [],
+			meta: {renamedHeaders: {c_1: 'c', c_2: 'c'}}
 		}
 	},
 ];
@@ -621,6 +625,7 @@ describe('Core Parser Tests', function() {
 			var actual = new Papa.Parser(test.config).parse(test.input);
 			assert.deepEqual(actual.errors, test.expected.errors);
 			assert.deepEqual(actual.data, test.expected.data);
+			assert.deepNestedInclude(actual.meta, test.expected.meta || {});
 		});
 	}
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1406,7 +1406,8 @@ var PARSE_TESTS = [
 				delimiter: ',',
 				cursor: 23,
 				aborted: false,
-				truncated: false
+				truncated: false,
+				renamedHeaders: null
 			}
 		}
 	},
@@ -1422,7 +1423,8 @@ var PARSE_TESTS = [
 				delimiter: ',',
 				cursor: 19,
 				aborted: false,
-				truncated: false
+				truncated: false,
+				renamedHeaders: null
 			}
 		}
 	},
@@ -1438,7 +1440,8 @@ var PARSE_TESTS = [
 				delimiter: ',',
 				cursor: 28,
 				aborted: false,
-				truncated: false
+				truncated: false,
+				renamedHeaders: null
 			}
 		}
 	},
@@ -1454,7 +1457,8 @@ var PARSE_TESTS = [
 				delimiter: ',',
 				cursor: 27,
 				aborted: false,
-				truncated: false
+				truncated: false,
+				renamedHeaders: null
 			}
 		}
 	},
@@ -1470,7 +1474,8 @@ var PARSE_TESTS = [
 				delimiter: ',',
 				cursor: 29,
 				aborted: false,
-				truncated: false
+				truncated: false,
+				renamedHeaders: null
 			}
 		}
 	},
@@ -1486,7 +1491,8 @@ var PARSE_TESTS = [
 				delimiter: ',',
 				cursor: 24,
 				aborted: false,
-				truncated: false
+				truncated: false,
+				renamedHeaders: null
 			}
 		}
 	},
@@ -1502,7 +1508,8 @@ var PARSE_TESTS = [
 				delimiter: ',',
 				cursor: 27,
 				aborted: false,
-				truncated: false
+				truncated: false,
+				renamedHeaders: null
 			}
 		}
 	},
@@ -1518,7 +1525,8 @@ var PARSE_TESTS = [
 				delimiter: ',',
 				cursor: 27,
 				aborted: false,
-				truncated: false
+				truncated: false,
+				renamedHeaders: null
 			}
 		}
 	},


### PR DESCRIPTION
Following #988 , the PR is ready for review.

This PR includes:

Added `Parser.meta` field called `renamedHeaders`.

- The value is `null` if the config is headless, or no renamed headers.
- The value is `Record<string, string>`, in which the keys are the renamed headers and the corresponding values are their original headers, or transformed headers.

The relevant unit tests are updated. I didn't assert all `meta` in existing unit tests by using `assert.deepEqual`. Instead, I used `assert.deepNestedInclude` to assert the values `renamedHeaders` are correct to avoid a monster PR.