### PR TITLE
Fast headerMap to find duplicated headers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
 		"ecmaVersion": 6
 	},
 	"env": {
+		"es6": true,
 		"browser": true,
 		"worker": true,
 		"node": true

--- a/papaparse.js
+++ b/papaparse.js
@@ -1472,7 +1472,7 @@ License: MIT
 				var firstLine = input.split(newline)[0];
 				var headers = firstLine.split(delim);
 				var separator = '_';
-				var headerMap = [];
+				var headerMap = new Set();
 				var headerCount = {};
 				var duplicateHeaders = false;
 
@@ -1488,15 +1488,15 @@ License: MIT
 						headerName = header + separator + count;
 					}
 					headerCount[header] = count + 1;
-					// In case it already exists, we add more separtors
-					while (headerMap.includes(headerName)) {
+					// In case it already exists, we add more separators
+					while (headerMap.has(headerName)) {
 						headerName = headerName + separator + count;
 					}
-					headerMap.push(headerName);
+					headerMap.add(headerName);
 				}
 				if (duplicateHeaders) {
 					var editedInput = input.split(newline);
-					editedInput[0] = headerMap.join(delim);
+					editedInput[0] = Array.from(headerMap).join(delim);
 					input = editedInput.join(newline);
 				}
 			}


### PR DESCRIPTION
The current implementation used to rely on an instance of `Array` and on its `includes` method. Depending on how many headers one may have to export in the CSV this `Array` can contain many entries and performings `includes` on it might be costly as it grows (most of the cases will have to iterate over the whole collection as duplicates is rather the exception than the rule).

The current PR proposes to rely on a native Set (when available) or a simple polyfill for it. (Side note: I did not know how to put tests on the polyfill as the class is internal and never exposed so I tested it manually on my side)

Related to https://github.com/mholt/PapaParse/commit/970c1dbaab0232c8d056ce1e58dbdcb5347e2206

Please feel free to close this PR if it does not make sense for the project. And thanks a lot for papaparse!