### PR TITLE
Fixed cursor when duplicated header

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1469,9 +1469,10 @@ License: MIT
 				return returnable();
 
 			// Rename headers if there are duplicates
+			var firstLine;
 			if (config.header && !baseIndex)
 			{
-				var firstLine = input.split(newline)[0];
+				firstLine = input.split(newline)[0];
 				var headers = firstLine.split(delim);
 				var separator = '_';
 				var headerMap = new Set();
@@ -1516,7 +1517,12 @@ License: MIT
 				for (var i = 0; i < rows.length; i++)
 				{
 					row = rows[i];
-					cursor += row.length;
+					// use firstline as row length may be changed due to duplicated headers
+					if (i === 0 && firstLine !== undefined) {
+						cursor += firstLine.length;
+					}else{
+						cursor += row.length;
+					}
 					if (i !== rows.length - 1)
 						cursor += newline.length;
 					else if (ignoreLastRow)

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -594,7 +594,10 @@ var CORE_PARSER_TESTS = [
 		expected: {
 			data: [['A', 'A_1', 'A_2', 'A_3'], ['1', '2', '3', '4']],
 			errors: [],
-			meta: {renamedHeaders: {A_1: 'A', A_2: 'A', A_3: 'A'}}
+			meta: {
+				renamedHeaders: {A_1: 'A', A_2: 'A', A_3: 'A'},
+				cursor: 15
+			}
 		}
 	},
 	{
@@ -604,7 +607,10 @@ var CORE_PARSER_TESTS = [
 		expected: {
 			data: [['a', 'a_1', 'a_2', 'a_3'], ['1', '2', '3', '4']],
 			errors: [],
-			meta: {renamedHeaders: {a_1: 'a', a_2: 'a', a_3: 'a'}}
+			meta: {
+				renamedHeaders: {a_1: 'a', a_2: 'a', a_3: 'a'},
+				cursor: 15
+			}
 		}
 	},
 	{
@@ -614,7 +620,10 @@ var CORE_PARSER_TESTS = [
 		expected: {
 			data: [['c', 'c_1', 'c_2', 'c_1_0'], ['1', '2', '3', '4']],
 			errors: [],
-			meta: {renamedHeaders: {c_1: 'c', c_2: 'c'}}
+			meta: {
+				renamedHeaders: {c_1: 'c', c_2: 'c'},
+				cursor: 17
+			}
 		}
 	},
 ];


### PR DESCRIPTION
When processing duplicate headers with header auto, the position of meta.cursor will be returned as the position of cursor including renamed headers such as _<number>. But it's different from the cursor of the actual file. So set the cursor to the length of the original header.