### PR TITLE
Add usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Usage
 
     import Papa from 'papaparse';
 
+    Papa.parse(file, config);
+    
+    const csv = Papa.unparse(data[, config]);
+
 Homepage & Demo
 ----------------
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ can be installed with the following command:
 
 If you don't want to use npm, [papaparse.min.js](https://unpkg.com/papaparse@latest/papaparse.min.js) can be downloaded to your project source.
 
+Usage
+-----
+
+    import Papa from 'papaparse';
 
 Homepage & Demo
 ----------------


### PR DESCRIPTION
This adds a usage section to the npm readme to show how to import PapaParse to a file

addresses concerns in #1001 