### PR TITLE
Skip lines future (Feature Suggestion) #738

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -450,7 +450,8 @@ var csv = Papa.unparse({
 	beforeFirstChunk: undefined,
 	withCredentials: undefined,
 	transform: undefined,
-	delimitersToGuess: [',', '\t', '|', ';', <a href="#readonly">Papa.RECORD_SEP</a>, <a href="#readonly">Papa.UNIT_SEP</a>]
+	delimitersToGuess: [',', '\t', '|', ';', <a href="#readonly">Papa.RECORD_SEP</a>, <a href="#readonly">Papa.UNIT_SEP</a>],
+	skipFirstNLines: 0
 }</code></pre>
 					</div>
 					<div class="clear"></div>
@@ -680,6 +681,14 @@ var csv = Papa.unparse({
 								</td>
 								<td>
 									An array of delimiters to guess from if the <code>delimiter</code> option is not set.
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<code>skipFirstNLines</code>
+								</td>
+								<td>
+									To skip first N number of lines when converting a CSV file to JSON 
 								</td>
 							</tr>
 						</table>

--- a/papaparse.js
+++ b/papaparse.js
@@ -484,6 +484,7 @@ License: MIT
 		}
 	}
 
+
 	/** ChunkStreamer is the base prototype for various streamer implementations. */
 	function ChunkStreamer(config)
 	{
@@ -519,8 +520,23 @@ License: MIT
 
 			// Rejoin the line we likely just split in two by chunking the file
 			var aggregate = this._partialLine + chunk;
+			this._pendingSkip = parseInt(this._config.skipFirstNLines) || 0;
+			this._skipHeader = 0;
+			if (this._config.header) {
+				this._skipHeader++;
+			}
+			if (this._pendingSkip > 0) {
+				var splitChunk = aggregate.split('\n');
+				var currentChunkLength = splitChunk.length;
+				if (currentChunkLength <= this._pendingSkip) {
+					aggregate = this._partialLine;
+				}
+				else{
+					aggregate = this._partialLine + [...splitChunk.slice(0, this._skipHeader), ...splitChunk.slice(this._skipHeader + this._pendingSkip)].join('\n');
+				}
+				this._pendingSkip -= currentChunkLength;
+			}
 			this._partialLine = '';
-
 			var results = this._handle.parse(aggregate, this._baseIndex, !this._finished);
 
 			if (this._handle.paused() || this._handle.aborted()) {
@@ -1929,7 +1945,6 @@ License: MIT
 	{
 		return function() { f.apply(self, arguments); };
 	}
-
 	function isFunction(func)
 	{
 		return typeof func === 'function';

--- a/player/player.html
+++ b/player/player.html
@@ -24,6 +24,7 @@
 				<label><input type="checkbox" id="skipEmptyLines"> Skip empty lines</label>
 				<label><input type="checkbox" id="step-pause"> Pause on step</label>
 				<label><input type="checkbox" id="print-steps"> Log each step/chunk</label>
+				<label>Skip First N Lines: <input type="number" id="skipFirstNLines"></label>
 				
 				<label>Delimiter: <input type="text" size="5" placeholder="auto" id="delimiter"> <a href="javascript:" id="insert-tab">tab</a></label>
 

--- a/player/player.js
+++ b/player/player.js
@@ -108,6 +108,7 @@ function buildConfig()
 		skipEmptyLines: $('#skipEmptyLines').prop('checked'),
 		chunk: $('#chunk').prop('checked') ? chunkFn : undefined,
 		beforeFirstChunk: undefined,
+		skipFirstNLines: $('#skipFirstNLines').val()
 	};
 
 	function getLineEnding()

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1574,6 +1574,42 @@ var PARSE_TESTS = [
 			data: [['a', 'b', 'c\n'], ['d', 'e', 'f']],
 			errors: []
 		}
+	},
+	{
+		description: "Skip First N number of lines , with header and 2 rows",
+		input: 'a,b,c,d\n1,2,3,4',
+		config: { header: true, skipFirstNLines: 1 },
+		expected: {
+			data: [],
+			errors: []
+		}
+	},
+	{
+		description: "Skip First N number of lines , with header and 3 rows",
+		input: 'a,b,c,d\n1,2,3,4\n4,5,6,7',
+		config: { header: true, skipFirstNLines: 1 },
+		expected: {
+			data: [{a: '4', b: '5', c: '6', d: '7'}],
+			errors: []
+		}
+	},
+	{
+		description: "Skip First N number of lines , with header false",
+		input: 'a,b,c,d\n1,2,3,4\n4,5,6,7',
+		config: { header: false, skipFirstNLines: 1 },
+		expected: {
+			data: [['1','2','3','4'],['4','5','6','7']],
+			errors: []
+		}
+	},
+	{
+		description: "Skip First N number of lines , with header false and skipFirstNLines as negative value",
+		input: 'a,b,c,d\n1,2,3,4\n4,5,6,7',
+		config: { header: false, skipFirstNLines: -2 },
+		expected: {
+			data: [['a','b','c','d'],['1','2','3','4'],['4','5','6','7']],
+			errors: []
+		}
 	}
 ];
 


### PR DESCRIPTION
 
## Issues No : #738

### Description:
In this feature enhancement, Added the capability to skip a defined number of lines when converting a CSV (Comma-Separated Values) file to JSON format. This functionality offers users more flexibility when dealing with CSV files with header information or metadata at the beginning, allowing for a more efficient and precise conversion process.

### Changes Made:

1. Introduced a new configuration parameter, skipFirstNLines, which allows users to specify the number of lines to skip at the beginning of the CSV file during the conversion to JSON. This parameter supports values from 0 and above.
2. Implemented validation for the skipFirstNLines configuration parameter to ensure that it does not negatively impact the parsing process, even if it is set to 0 or given a negative value.
3. Enhanced the user interface of the player.html file by adding an input field that allows users to input the desired value for skipFirstNLines.
4.  Updated the player.js script to retrieve and utilize the skipFirstNLines input from the user and incorporate it into the parser's configuration.


### Test cases:
 
Included test cases to validate the functionality of the skipFirstNLines feature, ensuring that it behaves correctly under various scenarios.

Test 1:  "Skip First N number of lines , with header",

Test 2: "Skip First N number of lines , without header",

Test 3: "Skip  First N lines with value as 0 with header false",

Test 4:  "Skip First N lines with value as 0 with header true",

Test 5: "Skip First N lines with value less then 0, with header true",
		
Test 6: "Without Skip First N Lines config",
