### PR TITLE
docs: fix default value of `header` to be `true`

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -430,7 +430,7 @@ var csv = Papa.unparse({
 	newline: "",	// auto-detect
 	quoteChar: '"',
 	escapeChar: '"',
-	header: false,
+	header: true,
 	transformHeader: undefined,
 	dynamicTyping: false,
 	preview: 0,


### PR DESCRIPTION
The default value of `header` in the config object is `true`, but the docs claim that it's `false`.

Here's the source code of the actual default value:
https://github.com/mholt/PapaParse/blob/841e1d420dd2758cccb60a2bc1f2fcffd327c251/papaparse.js#L275