### PR TITLE
fix: check _config.escapeFormulae is true

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -377,7 +377,7 @@ License: MIT
 				_escapedQuote = _config.escapeChar + _quoteChar;
 			}
 
-			if (_config.escapeFormulae instanceof RegExp  ) {
+			if (_config.escapeFormulae instanceof RegExp) {
 				_escapeFormulae = _config.escapeFormulae;
 			} else if (typeof _config.escapeFormulae === 'boolean' && _config.escapeFormulae) {
 				_escapeFormulae =  /^[=+\-@\t\r].*$/;

--- a/papaparse.js
+++ b/papaparse.js
@@ -377,8 +377,10 @@ License: MIT
 				_escapedQuote = _config.escapeChar + _quoteChar;
 			}
 
-			if (typeof _config.escapeFormulae === 'boolean' || _config.escapeFormulae instanceof RegExp) {
-				_escapeFormulae = _config.escapeFormulae instanceof RegExp ? _config.escapeFormulae : /^[=+\-@\t\r].*$/;
+			if (_config.escapeFormulae instanceof RegExp  ) {
+				_escapeFormulae = _config.escapeFormulae;
+			} else if (typeof _config.escapeFormulae === 'boolean' && _config.escapeFormulae) {
+				_escapeFormulae =  /^[=+\-@\t\r].*$/;
 			}
 		}
 


### PR DESCRIPTION
When parsing the config with a boolean value of `escapeFormulae`, the presence of the `escapeFormulae` key is checked but the value itself is not checked.

This means that `_config = {escapeFormulae: false}` behaves the same as `_config = {escapeFormulae: true}`.

[Codesandbox example](https://codesandbox.io/s/competent-goldberg-82vcqn?file=/src/App.tsx)

```ts
import "./styles.css";
import Papa from "papaparse";

export default function App() {
  const data = [
    ["a", "b"],
    [1, "=1+2"]
  ];
  const emptyConfigResult = Papa.unparse(data, {});
  const escapeFormulaeFalseResult = Papa.unparse(data, {
    escapeFormulae: false
  });
  const escapeFormulaeTrueResult = Papa.unparse(data, { escapeFormulae: true });

  return (
    <div className="App">
      <h3>Empty config</h3>
      <pre>{emptyConfigResult}</pre>
      <h3>escapeFormulae = false</h3>
      <pre>{escapeFormulaeFalseResult}</pre>
      <h3>escapeFormulae = true</h3>
      <pre>{escapeFormulaeTrueResult}</pre>
    </div>
  );
}
```

Result
```
Empty config

a,b
1,=1+2

escapeFormulae = false

a,b
1,"'=1+2"

escapeFormulae = true

a,b
1,"'=1+2"
```

This PR adds a check that `escapeFormulae` is truthy before using the default regex for escaping formulae.