### PR TITLE
strip BOM when streaming chunk

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -186,7 +186,13 @@ License: MIT
 	}
 
 
-
+	// Strip character from UTF-8 BOM encoded files that cause issue parsing the file
+	function stripBom(string) {
+		if (string.charCodeAt(0) === 0xfeff) {
+			return string.slice(1);
+		}
+		return string;
+	}
 
 	function CsvToJson(_input, _config)
 	{
@@ -249,14 +255,6 @@ License: MIT
 			streamer = new FileStreamer(_config);
 
 		return streamer.stream(_input);
-
-		// Strip character from UTF-8 BOM encoded files that cause issue parsing the file
-		function stripBom(string) {
-			if (string.charCodeAt(0) === 0xfeff) {
-				return string.slice(1);
-			}
-			return string;
-		}
 	}
 
 
@@ -513,6 +511,7 @@ License: MIT
 			// First chunk pre-processing
 			if (this.isFirstChunk && isFunction(this._config.beforeFirstChunk))
 			{
+				chunk = stripBom(chunk);
 				var modifiedChunk = this._config.beforeFirstChunk(chunk);
 				if (modifiedChunk !== undefined)
 					chunk = modifiedChunk;


### PR DESCRIPTION
when parsing a CSV and using step, we stream the file but papaparse does not handle the BOM like it does when it is handling a string.  so i moved the function stripBom to a place where it can be reused and then called the function on the first chunk only since it can only happen then.