### PR TITLE
Update papaparse link in package.json to use HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"multi-threaded",
 		"jquery-plugin"
 	],
-	"homepage": "http://papaparse.com",
+	"homepage": "https://www.papaparse.com/",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/mholt/PapaParse.git"


### PR DESCRIPTION
This is used when showing the URL in NPM, and causes browser security warnings when clicking through to the site.