### PR TITLE
Fix improper handling of msg.results in chunk callbacks (#964)

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1866,24 +1866,25 @@ License: MIT
 					if (aborted)
 						break;
 				}
-				delete msg.results;	// free memory ASAP
 			}
 			else if (isFunction(worker.userChunk))
 			{
 				worker.userChunk(msg.results, handle, msg.file);
-				delete msg.results;
 			}
 		}
 
 		if (msg.finished && !aborted)
-			completeWorker(msg.workerId, msg.results);
+			completeWorker(msg.workerId, msg.results, msg.file);
+
+		delete msg.results;
 	}
 
-	function completeWorker(workerId, results) {
+	function completeWorker(workerId, results, file) {
 		var worker = workers[workerId];
-		if (isFunction(worker.userComplete))
-			worker.userComplete(results);
-		worker.terminate();
+		if (isFunction(worker.userComplete)) {
+			worker.userComplete(results, file);
+			worker.terminate();
+		}
 		delete workers[workerId];
 	}
 


### PR DESCRIPTION
Fix #964.

The `delete msg.results;` statement was likely introduced for memory optimization.
However, this caused the results to not be correctly passed as a parameter to `complete` when a chunk callback was present.

To address this, the release point of `msg.results` has been adjusted to ensure that results are properly passed to `complete` in cases where a chunk callback is used.