### PR TITLE
Add allowDuplicateHeaders option to configuration and update tests

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -450,6 +450,7 @@ var csv = Papa.unparse({
 	beforeFirstChunk: undefined,
 	withCredentials: undefined,
 	transform: undefined,
+	allowDuplicateHeaders: undefined,
 	delimitersToGuess: [',', '\t', '|', ';', <a href="#readonly">Papa.RECORD_SEP</a>, <a href="#readonly">Papa.UNIT_SEP</a>],
 	skipFirstNLines: 0
 }</code></pre>

--- a/papaparse.js
+++ b/papaparse.js
@@ -1741,7 +1741,7 @@ License: MIT
 			/** Returns an object with the results, errors, and meta. */
 			function returnable(stopped)
 			{
-				if (config.header && !baseIndex && data.length)
+				if (config.header && !config.allowDuplicateHeaders && !baseIndex && data.length)
 				{
 					var result = data[0];
 					var headerCount = {}; // To track the count of each base header

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -601,6 +601,19 @@ var CORE_PARSER_TESTS = [
 		}
 	},
 	{
+		description: "Simple duplicated header names (allowDuplicateHeaders=true)",
+		input: 'A,A,A,A\n1,2,3,4',
+		config: { header: true, allowDuplicateHeaders: true },
+		expected: {
+			data: [['A', 'A', 'A', 'A'], ['1', '2', '3', '4']],
+			errors: [],
+			meta: {
+				renamedHeaders: null,
+				cursor: 15
+			}
+		}
+	},
+	{
 		description: "Duplicated header names with headerTransform",
 		input: 'A,A,A,A\n1,2,3,4',
 		config: { header: true, transformHeader: function(header) { return header.toLowerCase(); } },


### PR DESCRIPTION
The automatic duplicate header parsing introduced in a recent version, while helpful for new development, has broken existing legacy code in our codebase.

This PR adds a flag `allowDuplicateHeaders` which can be set to true to revert to the earlier functionality (as seen in v5.2.0 - that's the version we were on)

Let me know if this PR needs anything else and thanks for the consideration! Love papaparse :) 

