### PR TITLE
Strip BOM character from column keys when parsing header, add BOM tests

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -185,8 +185,14 @@ License: MIT
 		global.onmessage = workerThreadReceivedMessage;
 	}
 
-
-
+	// Strip character from UTF-8 BOM encoded files that cause issue parsing the file
+	function stripBom(string) {
+		console.log(`checking ${string}`);
+		if (string.charCodeAt(0) === 0xfeff) {
+			return string.slice(1);
+		}
+		return string;
+	}
 
 	function CsvToJson(_input, _config)
 	{
@@ -249,14 +255,6 @@ License: MIT
 			streamer = new FileStreamer(_config);
 
 		return streamer.stream(_input);
-
-		// Strip character from UTF-8 BOM encoded files that cause issue parsing the file
-		function stripBom(string) {
-			if (string.charCodeAt(0) === 0xfeff) {
-				return string.slice(1);
-			}
-			return string;
-		}
 	}
 
 
@@ -1234,6 +1232,7 @@ License: MIT
 
 			function addHeader(header, i)
 			{
+				header = stripBom(header);
 				if (isFunction(_config.transformHeader))
 					header = _config.transformHeader(header, i);
 
@@ -1750,7 +1749,7 @@ License: MIT
 					let duplicateHeaders = false;
 
 					for (let i = 0; i < result.length; i++) {
-						let header = result[i];
+						let header = stripBom(result[i]);
 						if (isFunction(config.transformHeader))
 							header = config.transformHeader(header, i);
 

--- a/papaparse.js
+++ b/papaparse.js
@@ -187,7 +187,6 @@ License: MIT
 
 	// Strip character from UTF-8 BOM encoded files that cause issue parsing the file
 	function stripBom(string) {
-		console.log(`checking ${string}`);
 		if (string.charCodeAt(0) === 0xfeff) {
 			return string.slice(1);
 		}

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1540,6 +1540,24 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "UTF-8 BOM encoded input is stripped from invisible BOM character",
+		input: '\ufeffA,B\nX,Y',
+		config: {},
+		expected: {
+			data: [['A', 'B'], ['X', 'Y']],
+			errors: [],
+		}
+	},
+	{
+		description: "UTF-8 BOM encoded input with header produces column key stripped from invisible BOM character",
+		input: '\ufeffA,B\nX,Y',
+		config: { header: true },
+		expected: {
+			data: [{A: 'X', B: 'Y'}],
+			errors: [],
+		}
+	},
+	{
 		description: "Parsing with skipEmptyLines set to 'greedy'",
 		notes: "Must parse correctly without lines with no content",
 		input: 'a,b\n\n,\nc,d\n , \n""," "\n	,	\n,,,,\n',
@@ -1688,6 +1706,18 @@ var PARSE_ASYNC_TESTS = [
 		},
 		expected: {
 			data: [['A','B','C'],['X','Y','Z']],
+			errors: []
+		}
+	},
+	{
+		description: "Simple file with BOM encoding and header",
+		disabled: !FILES_ENABLED,
+		input: FILES_ENABLED ? new File(["\ufeffA,B\nX,Y"], "sample.csv") : false,
+		config: {
+			header: true,
+		},
+		expected: {
+			data: [{'\ufeffA': 'X', B: 'Y'}],
 			errors: []
 		}
 	},

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1710,18 +1710,6 @@ var PARSE_ASYNC_TESTS = [
 		}
 	},
 	{
-		description: "Simple file with BOM encoding and header",
-		disabled: !FILES_ENABLED,
-		input: FILES_ENABLED ? new File(["\ufeffA,B\nX,Y"], "sample.csv") : false,
-		config: {
-			header: true,
-		},
-		expected: {
-			data: [{'\ufeffA': 'X', B: 'Y'}],
-			errors: []
-		}
-	},
-	{
 		description: "Simple file + worker",
 		disabled: !FILES_ENABLED,
 		input: FILES_ENABLED ? new File(["A,B,C\nX,Y,Z"], "sample.csv") : false,


### PR DESCRIPTION
Addresses #372, stripping BOM from column keys when parsing the header.
The problem: The first column key includes the invisible BOM character if it exists in the CSV.

Pull request #961 handled BOM stripping for parsing the CSV without keyed data. However, with `header: true` the issue still persisted. This is solved by this pull request that runs the `stripBom` function from #961 also on the header field, before 'transformHeader'.

Also, I added tests for BOM handling.