### PR TITLE
Fix header name counting issue

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1745,7 +1745,7 @@ License: MIT
 				if (config.header && !baseIndex && data.length && !headerParsed)
 				{
 					const result = data[0];
-					const headerCount = {}; // To track the count of each base header
+					const headerCount = Object.create(null); // To track the count of each base header
 					const usedHeaders = new Set(result); // To track used headers and avoid duplicates
 					let duplicateHeaders = false;
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -626,6 +626,19 @@ var CORE_PARSER_TESTS = [
 			}
 		}
 	},
+	{
+		description: "Duplicate header names with __proto__ field",
+		input: '__proto__,__proto__,__proto__\n1,2,3',
+		config: { header: true },
+		expected: {
+			data: [['__proto__', '__proto___1', '__proto___2'], ['1', '2', '3']],
+			errors: [],
+			meta: {
+				renamedHeaders: {__proto___1: '__proto__', __proto___2: '__proto__'},
+				cursor: 35
+			}
+		}
+	},
 ];
 
 describe('Core Parser Tests', function() {


### PR DESCRIPTION
Using `__proto__` as a header name and repeating it can cause an infinite loop due to incorrect counting. This issue can be resolved by replacing {} with an object that has no prototype.