### PR TITLE
Mention BYTE_ORDER_MARK in documentation

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -878,6 +878,12 @@ var csv = Papa.unparse({
 								</td>
 							</tr>
 							<tr>
+								<td><code>Papa.BYTE_ORDER_MARK</code></td>
+								<td>
+									The unicode <a href="https://en.wikipedia.org/wiki/Byte_order_mark">Byte Order Mark</a> (<code>\ufeff</code>).
+								</td>
+							</tr>
+							<tr>
 								<td><code>Papa.RECORD_SEP</code></td>
 								<td>
 									The true delimiter. Invisible. ASCII code 30. Should be doing the job we strangely rely upon commas and tabs for.


### PR DESCRIPTION
Adding this to the documentation so that it can be added to the definitely typed definition, as documentation indicates that it is a stable property.