### PR TITLE
Update Node versions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [20.x, 22.x, 24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -13,6 +13,8 @@ var UNIT_SEP = String.fromCharCode(31);
 var FILES_ENABLED = false;
 try {
 	new File([""], ""); // eslint-disable-line no-new
+	// Required since Node20 as it ads a FileGlobal but not a FileReaderSync
+	new FileReaderSync(); // eslint-disable-line no-new
 	FILES_ENABLED = true;
 } catch (e) {} // safari, ie
 
@@ -2817,7 +2819,7 @@ describe('Custom Tests', function() {
 		const blob = new Blob([
 			`
 				importScripts('${papaParseScriptPath}');
-				
+
 				self.addEventListener("message", function(event) {
 					if (event.data === "ExecuteParse") {
 						// Perform our synchronous parse, as requested


### PR DESCRIPTION
Drop versions that are EOL and add newer versions.

Node 18 has been end of life since March 27, 2025