### PR TITLE
Update README.md: HTTP => HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ const csv = Papa.unparse(data[, config]);
 Homepage & Demo
 ----------------
 
-- [Homepage](http://papaparse.com)
-- [Demo](http://papaparse.com/demo)
+- [Homepage](https://www.papaparse.com)
+- [Demo](https://www.papaparse.com/demo)
 
 To learn how to use Papa Parse:
 
-- [Documentation](http://papaparse.com/docs)
+- [Documentation](https://www.papaparse.com/docs)
 
 The website is hosted on [Github Pages](https://pages.github.com/). Its content is also included in the docs folder of this repository. If you want to contribute on it just clone the master of this repository and open a pull request.
 
@@ -62,7 +62,7 @@ Papa Parse can also parse in a node streaming style which makes `.pipe` availabl
 Get Started
 -----------
 
-For usage instructions, see the [homepage](http://papaparse.com) and, for more detail, the [documentation](http://papaparse.com/docs).
+For usage instructions, see the [homepage](https://www.papaparse.com) and, for more detail, the [documentation](https://www.papaparse.com/docs).
 
 Tests
 -----


### PR DESCRIPTION
as one gets a warning now in chrome when opening a HTTP-only link

<img width="2741" height="1748" alt="image" src="https://github.com/user-attachments/assets/52329d4c-539e-4178-9b09-4767fc77249f" />

switch to HTTPS links.

as https://papaparse.com/ doesn't appear to have a valid cert

<img width="2751" height="1536" alt="image" src="https://github.com/user-attachments/assets/074ad86c-2766-401d-9fda-2f1be612c67f" />

but https://www.papaparse.com/ does, immediately link there o7