### PR TITLE
fix(guessLineEndings): detect CRLF data after an LF header (stop leaking a stray \r into fields)

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1165,23 +1165,22 @@ License: MIT
 			var re = new RegExp(escapeRegExp(quoteChar) + '([^]*?)' + escapeRegExp(quoteChar), 'gm');
 			input = input.replace(re, '');
 
-			var r = input.split('\r');
+			// Count each line-ending style and pick the most frequent. Counting
+			// \r\n explicitly (rather than inferring from which of \r/\n appears
+			// first) avoids mis-detecting a CRLF file as LF when an early lone \n
+			// precedes the CRLF rows (e.g. an LF header line followed by CRLF data),
+			// which previously left a stray \r on every row's last field.
+			var crlf = (input.match(/\r\n/g) || []).length;
+			var totalR = input.split('\r').length - 1;
+			var totalN = input.split('\n').length - 1;
+			var loneR = totalR - crlf;
+			var loneN = totalN - crlf;
 
-			var n = input.split('\n');
-
-			var nAppearsFirst = (n.length > 1 && n[0].length < r[0].length);
-
-			if (r.length === 1 || nAppearsFirst)
-				return '\n';
-
-			var numWithN = 0;
-			for (var i = 0; i < r.length; i++)
-			{
-				if (r[i][0] === '\n')
-					numWithN++;
-			}
-
-			return numWithN >= r.length / 2 ? '\r\n' : '\r';
+			if (crlf > 0 && crlf >= loneR && crlf >= loneN)
+				return '\r\n';
+			if (loneR > 0 && loneR >= loneN)
+				return '\r';
+			return '\n';
 		};
 
 		function testEmptyLine(s) {


### PR DESCRIPTION
## Bug

With default options, a CSV whose **header uses `\n`** but whose **data rows use `\r\n`** is mis-detected as LF-delimited, leaving a stray `\r` merged into every CRLF row’s last field — silently, with `errors: []`.

```js
const Papa = require("papaparse");
const input = "name,city\nAlice,NYC\r\nBob,LA\r\nCarol,SF";
Papa.parse(input, { header: true });
// meta.linebreak === "\n"
// data: [{name:"Alice",city:"NYC\r"}, {name:"Bob",city:"LA\r"}, {name:"Carol",city:"SF"}]
// errors: []
```

## Cause

`guessLineEndings` returns `"\n"` early when `nAppearsFirst` is true (the first `\n` precedes the first `\r`). A single early lone `\n` (the LF header) therefore overrides a CRLF-majority file, and the existing CRLF-vs-CR tally at the end of the function is never reached.

## Fix

Count each line-ending style (`\r\n`, lone `\r`, lone `\n`) and return the most frequent — no dependence on which appears first.

Verified against:

| input | detected |
|---|---|
| LF header + CRLF rows (bug case) | `\r\n` ✅ (was `\n`) |
| pure LF | `\n` ✅ |
| pure CRLF | `\r\n` ✅ |
| pure CR (old Mac) | `\r` ✅ |
| single line | `\n` ✅ |
| CRLF-majority + 1 LF | `\r\n` ✅ |
| LF-majority + 1 CRLF | `\n` ✅ |

All previously-correct cases are unchanged; only the mixed-EOL mis-detection is corrected. Happy to add a test in `tests/` if you point me at the preferred fixture style.