### PR TITLE
fix: correctly escape and quote custom quoteChar in unparse

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -357,8 +357,10 @@ License: MIT
 			if (typeof _config.newline === 'string')
 				_newline = _config.newline;
 
-			if (typeof _config.quoteChar === 'string')
+			if (typeof _config.quoteChar === 'string') {
 				_quoteChar = _config.quoteChar;
+				_escapedQuote = _quoteChar + _quoteChar;
+			}
 
 			if (typeof _config.header === 'boolean')
 				_writeHeader = _config.header;
@@ -460,7 +462,8 @@ License: MIT
 				needsQuotes = true;
 			}
 
-			var escapedQuoteStr = str.toString().replace(quoteCharRegex, _escapedQuote);
+			var strValue = str.toString();
+			var escapedQuoteStr = strValue.replace(quoteCharRegex, _escapedQuote);
 
 			needsQuotes = needsQuotes
 							|| _quotes === true
@@ -468,6 +471,7 @@ License: MIT
 							|| (Array.isArray(_quotes) && _quotes[col])
 							|| hasAny(escapedQuoteStr, Papa.BAD_DELIMITERS)
 							|| escapedQuoteStr.indexOf(_delimiter) > -1
+							|| strValue.indexOf(_quoteChar) > -1
 							|| escapedQuoteStr.charAt(0) === ' '
 							|| escapedQuoteStr.charAt(escapedQuoteStr.length - 1) === ' ';
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -2065,12 +2065,6 @@ var UNPARSE_TESTS = [
 		expected: 'a,+x++y+'
 	},
 	{
-		description: "Custom quoteChar quotes a field containing the quoteChar",
-		input: [['a@b', 'c']],
-		config: {header: false, quoteChar: '@'},
-		expected: '@a@@b@,c'
-	},
-	{
 		description: "Custom quoteChar with custom escapeChar quotes and escapes embedded quoteChar",
 		input: [['a', 'x+y']],
 		config: {header: false, quoteChar: '+', escapeChar: '\\'},

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -2059,6 +2059,24 @@ var UNPARSE_TESTS = [
 		expected: 'foo,"""quoted"""'
 	},
 	{
+		description: "Custom quoteChar escapes and quotes embedded quoteChar (no escapeChar)",
+		input: [['a', 'x+y']],
+		config: {header: false, quoteChar: '+'},
+		expected: 'a,+x++y+'
+	},
+	{
+		description: "Custom quoteChar quotes a field containing the quoteChar",
+		input: [['a@b', 'c']],
+		config: {header: false, quoteChar: '@'},
+		expected: '@a@@b@,c'
+	},
+	{
+		description: "Custom quoteChar with custom escapeChar quotes and escapes embedded quoteChar",
+		input: [['a', 'x+y']],
+		config: {header: false, quoteChar: '+', escapeChar: '\\'},
+		expected: 'a,+x\\+y+'
+	},
+	{
 		description: "Escape formulae",
 		input: [{ "Col1": "=danger", "Col2": "@danger", "Col3": "safe" }, { "Col1": "safe=safe", "Col2": "+danger", "Col3": "-danger, danger" }, { "Col1": "'+safe", "Col2": "'@safe", "Col3": "safe, safe" }],
 		config: { escapeFormulae: true },
@@ -2079,7 +2097,7 @@ var UNPARSE_TESTS = [
 		description: "Escape formulae with single-quote quoteChar and escapeChar",
 		input: [{ "Col1": "=danger", "Col2": "@danger", "Col3": "safe" }, { "Col1": "safe=safe", "Col2": "+danger", "Col3": "-danger, danger" }, { "Col1": "'+safe", "Col2": "'@safe", "Col3": "safe, safe" }],
 		config: { escapeFormulae: true, quoteChar: "'", escapeChar: "'" },
-		expected: 'Col1,Col2,Col3\r\n\'\'\'=danger\',\'\'\'@danger\',safe\r\nsafe=safe,\'\'\'+danger\',\'\'\'-danger, danger\'\r\n\'\'+safe,\'\'@safe,\'safe, safe\''
+		expected: 'Col1,Col2,Col3\r\n\'\'\'=danger\',\'\'\'@danger\',safe\r\nsafe=safe,\'\'\'+danger\',\'\'\'-danger, danger\'\r\n\'\'\'+safe\',\'\'\'@safe\',\'safe, safe\''
 	},
 	{
 		description: "Escape formulae with single-quote quoteChar and escapeChar and forced quotes",


### PR DESCRIPTION
## Problem

When a custom `quoteChar` is passed to `Papa.unparse` (without an explicit `escapeChar`), two things go wrong:

1. The escaped-quote sequence (`_escapedQuote`) is left at its default `""` instead of being derived from the custom `quoteChar`, so an embedded quoteChar is escaped with the wrong character.
2. A field that contains the custom `quoteChar` is **not** detected as needing quotes, so it is emitted unquoted. Combined with (1), this produces output that cannot be parsed back — a round-trip loses data.

```js
Papa.unparse([['a', 'x+y']], { quoteChar: '+' })
// before: a,+x""y+      (wrong escape, and 2nd field not quoted -> reparses to x""y)
// after:  a,+x++y+        (round-trips back to x+y)
```

A clearer data-corruption case (quoteChar in the middle of a value):

```js
Papa.unparse([["ab'cd", 'next']], { quoteChar: "'", escapeChar: "'" })
// before: ab''cd,next     -> Papa.parse(...) === [['ab''cd','next']]   (corrupted)
// after:  'ab''cd',next    -> Papa.parse(...) === [['ab'cd','next']]    (correct)
```

This is the root cause reported in #1068 (and underlies the confusion in #1035).

## Fix

- `unpackConfig()` now sets `_escapedQuote = _quoteChar + _quoteChar` when `quoteChar` is configured. The existing explicit-`escapeChar` branch runs afterwards and still overrides it, so `escapeChar` behavior is unchanged.
- `safe()` now also marks a field as needing quotes when the value contains the `quoteChar` (generalizing the existing `BAD_DELIMITERS` check, which only covered the default `"`).

## Tests

- Added 3 unparse fixtures covering custom `quoteChar` with and without a custom `escapeChar`.
- Updated one existing fixture ("Escape formulae with single-quote quoteChar and escapeChar") whose expected output encoded the previous buggy, non-round-trippable behavior; the new expected output is RFC-consistent and round-trips correctly.
- Full suite green (`npm run test-node`, `npm run lint`).

Closes #1068