### PR TITLE
fix: suppress false-positive UndetectableDelimiter error for single-column CSVs

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1343,6 +1343,7 @@ License: MIT
 
 		function guessDelimiter(input, newline, skipEmptyLines, comments, delimitersToGuess) {
 			var bestDelim, bestDelta, fieldCountPrevRow, maxFieldCount;
+			var singleColumnConsistent = false;
 
 			delimitersToGuess = delimitersToGuess || [',', '\t', '|', ';', Papa.RECORD_SEP, Papa.UNIT_SEP];
 
@@ -1379,6 +1380,13 @@ License: MIT
 				if (preview.data.length > 0)
 					avgFieldCount /= (preview.data.length - emptyLinesCount);
 
+				// A valid single-column CSV with multiple rows has no delimiter to detect;
+				// suppress the false-positive UndetectableDelimiter error in that case.
+				// Require more than one non-empty row to avoid masking genuine single-field issues.
+				if (!singleColumnConsistent && delta === 0 && avgFieldCount === 1
+						&& (preview.data.length - emptyLinesCount) > 1)
+					singleColumnConsistent = true;
+
 				if ((typeof bestDelta === 'undefined' || delta <= bestDelta)
 					&& (typeof maxFieldCount === 'undefined' || avgFieldCount > maxFieldCount) && avgFieldCount > 1.99) {
 					bestDelta = delta;
@@ -1390,8 +1398,8 @@ License: MIT
 			_config.delimiter = bestDelim;
 
 			return {
-				successful: !!bestDelim,
-				bestDelimiter: bestDelim
+				successful: !!bestDelim || singleColumnConsistent,
+				bestDelimiter: bestDelim || (singleColumnConsistent ? Papa.DefaultDelimiter : undefined)
 			};
 		}
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1292,6 +1292,26 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Single-column CSV does not emit false-positive UndetectableDelimiter error",
+		notes: "A valid single-column CSV has no field delimiter but should parse cleanly without errors",
+		input: 'id\n1\n2\n3',
+		config: {},
+		expected: {
+			data: [['id'], ['1'], ['2'], ['3']],
+			errors: []
+		}
+	},
+	{
+		description: "Single-column CSV with header does not emit UndetectableDelimiter error",
+		notes: "header:true on a single-column CSV should not produce a false-positive delimiter error",
+		input: 'id\n1\n2\n3',
+		config: { header: true },
+		expected: {
+			data: [{ id: '1' }, { id: '2' }, { id: '3' }],
+			errors: []
+		}
+	},
+	{
 		description: "Lines with comments are not used when guessing the delimiter in an escaped file",
 		notes: "Guessing the delimiter should work even if there are many lines of comments at the start of the file",
 		input: '#1\n#2\n#3\n#4\n#5\n#6\n#7\n#8\n#9\n#10\none,"t,w,o",three\nfour,five,six',


### PR DESCRIPTION
## Problem

When parsing a valid single-column CSV string without specifying `delimiter`, `Papa.parse()` emits a spurious `UndetectableDelimiter` error even though the data is parsed correctly.

```js
Papa.parse('id\n1\n2\n3')
// data: [['id'],['1'],['2'],['3']]  ← correct
// errors: [{ type: 'Delimiter', code: 'UndetectableDelimiter', ... }]  ← false positive
```

Reported in #1111.

## Root cause

`guessDelimiter()` only accepts a delimiter candidate when `avgFieldCount > 1.99`. A single-column CSV produces `avgFieldCount === 1` for every candidate delimiter, so no candidate is accepted and `_delimiterError` is set, triggering the error — even though the file is parsed correctly.

## Fix

Track a `singleColumnConsistent` flag inside `guessDelimiter()`: if any candidate delimiter produces perfectly consistent single-field rows (`delta === 0`, `avgFieldCount === 1`) across **more than one non-empty row**, the input is a valid single-column CSV, not a detection failure. In that case, return `successful: true` with the default comma delimiter.

Single-row inputs (`'Abc def'`) retain the existing error because a lone field is genuinely ambiguous.

## Tests

Two new test cases added to `tests/test-cases.js`:

- *Single-column CSV does not emit false-positive UndetectableDelimiter error*
- *Single-column CSV with header does not emit UndetectableDelimiter error*

All 249 passing tests continue to pass (`npm run test-node`); no existing tests were modified.

> AI-assisted contribution (GitHub Copilot / Claude)