### PR TITLE
fix: make line-ending detection aware of a custom escapeChar

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -517,7 +517,7 @@ License: MIT
 				let _newline = this._config.newline;
 				if (!_newline) {
 					const quoteChar = this._config.quoteChar || '"';
-					_newline = this._handle.guessLineEndings(chunk, quoteChar);
+					_newline = this._handle.guessLineEndings(chunk, quoteChar, this._config.escapeChar);
 				}
 				const splitChunk = chunk.split(_newline);
 				chunk = [...splitChunk.slice(skipFirstNLines)].join(_newline);
@@ -1088,7 +1088,7 @@ License: MIT
 		{
 			var quoteChar = _config.quoteChar || '"';
 			if (!_config.newline)
-				_config.newline = this.guessLineEndings(input, quoteChar);
+				_config.newline = this.guessLineEndings(input, quoteChar, _config.escapeChar);
 
 			_delimiterError = false;
 			if (!_config.delimiter)
@@ -1162,9 +1162,15 @@ License: MIT
 			_input = '';
 		};
 
-		this.guessLineEndings = function(input, quoteChar)
+		this.guessLineEndings = function(input, quoteChar, escapeChar)
 		{
 			input = input.substring(0, 1024 * 1024);	// max length 1 MB
+			// Remove escaped quotes so they do not break the quote pairing below
+			// (with a distinct escapeChar an embedded quote is escapeChar+quoteChar,
+			// not a doubled quoteChar, which would otherwise mis-pair the quotes).
+			if (escapeChar && escapeChar !== quoteChar) {
+				input = input.split(escapeChar + quoteChar).join('');
+			}
 			// Replace all the text inside quotes
 			var re = new RegExp(escapeRegExp(quoteChar) + '([^]*?)' + escapeRegExp(quoteChar), 'gm');
 			input = input.replace(re, '');

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -688,6 +688,16 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Custom escapeChar does not break line-ending detection",
+		notes: "A carriage return inside a field must not be mistaken for the row separator when escapeChar is set",
+		input: '"\\"","\r"\r\nz,z',
+		config: { escapeChar: '\\', delimiter: ',' },
+		expected: {
+			data: [['"', '\r'], ['z', 'z']],
+			errors: []
+		}
+	},
+	{
 		description: "Quoted field with \\r",
 		input: 'A,"B\rB",C',
 		expected: {


### PR DESCRIPTION
### Problem

`guessLineEndings` strips quoted regions before counting `\r` / `\n`, using a regex that pairs `quoteChar` with `quoteChar`. With a **distinct `escapeChar`**, an embedded quote is serialized as `escapeChar` + `quoteChar` (e.g. `\"`) rather than a doubled `quoteChar`, so the pairing is thrown off and a carriage return that is field data is left exposed. The line ending is then guessed as `\r` instead of `\r\n`; `parse` splits on `\r`, and a stray `\n` is glued onto the next row's first field — corrupting the data on an `unparse` → `parse` round-trip with the same config:

```js
const Papa = require('papaparse');
const cfg = { escapeChar: '\\' };

const rows = [['"', '\r'], ['z', 'z']];
const csv  = Papa.unparse(rows, cfg);      // '"\\"","\r"\r\nz,z'
Papa.parse(csv, cfg).data;
// [['"', '\r'], ['\nz', 'z']]   (meta.linebreak === '\r')
// expected: [['"', '\r'], ['z', 'z']]
```

The default configuration round-trips fine, because the RFC `""` doubling keeps the quote count even; only a distinct `escapeChar` produces the odd `\"` that mis-pairs the quotes.

### Fix

Before the quote-pairing pass, remove `escapeChar + quoteChar` sequences when `escapeChar !== quoteChar`, so escaped quotes no longer break the pairing. `escapeChar` is passed through from both call sites. Removing those two characters cannot change the `\r` / `\n` counts, and the default config (`escapeChar === quoteChar`) is left completely unchanged.

### Test

Added a parse test for a `\r`-containing field with `escapeChar: '\\'`. It fails before the change and passes after. `npm run lint` and `npm run test-node` are green (248 passing).