### PR TITLE
fix: do not flag a malformed-quote error when a \r\n line ending is s…

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1625,6 +1625,14 @@ License: MIT
 						}
 
 
+						// When streaming, a closing quote with no further newline left in this
+						// chunk means the row is still incomplete -- most likely a delimiter or
+						// newline split across the chunk boundary (e.g. a "\r\n" cut right after
+						// the "\r"). Defer the row to the next chunk instead of reporting a
+						// spurious malformed-quote error. (#1103)
+						if (ignoreLastRow && nextNewline === -1)
+							return finish();
+
 						// Checks for valid closing quotes are complete (escaped quotes or quote followed by EOF/delimiter/newline) -- assume these quotes are part of an invalid text string
 						errors.push({
 							type: 'Quotes',

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -2311,6 +2311,31 @@ var CUSTOM_TESTS = [
 		}
 	},
 	{
+		description: "Quoted field with \\r\\n line ending split across a chunk boundary does not emit a spurious InvalidQuotes error (#1103)",
+		expected: [[['a', 'bc'], ['d', 'ef']], []],
+		run: function(callback) {
+			var data = [];
+			var errors = [];
+			// chunkSize 9 makes the first chunk end on the "\r" of the first "\r\n",
+			// splitting the line ending across the chunk boundary. The closing quote of
+			// "bc" is then followed only by a lone "\r" (neither a delimiter nor a full
+			// newline), which previously tripped a false "Trailing quote on quoted field
+			// is malformed" error even though the row is simply incomplete.
+			Papa.parse('"a","bc"\r\n"d","ef"', {
+				delimiter: ',',
+				newline: '\r\n',
+				chunkSize: 9,
+				chunk: function(results) {
+					data = data.concat(results.data);
+					errors = errors.concat(results.errors);
+				},
+				complete: function() {
+					callback([data, errors]);
+				}
+			});
+		}
+	},
+	{
 		description: "Step is called for each row",
 		expected: 2,
 		run: function(callback) {


### PR DESCRIPTION
…plit across a chunk boundary (#1103)

When streaming, a chunk can end on the \r of a \r\n line ending, leaving a closing quote followed only by a lone \r. That \r matches neither the delimiter nor a full newline, so the parser reported a spurious "Trailing quote on quoted field is malformed" (InvalidQuotes) error even though the row is simply incomplete and is already deferred to the next chunk via _partialLine (no data is lost).

Guard the InvalidQuotes branch: when ignoreLastRow is set (more chunks are coming) and there is no further newline left in this chunk, defer the row instead of emitting the error. Genuine malformed quotes are unaffected (there a newline still follows, or it is the final chunk).

Adds a regression test that parses a quoted CSV with a \r\n line ending split across a chunk boundary and asserts no error is produced.