### PR TITLE
fix: guess delimiter by row consistency before field count

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1379,8 +1379,11 @@ License: MIT
 				if (preview.data.length > 0)
 					avgFieldCount /= (preview.data.length - emptyLinesCount);
 
-				if ((typeof bestDelta === 'undefined' || delta <= bestDelta)
-					&& (typeof maxFieldCount === 'undefined' || avgFieldCount > maxFieldCount) && avgFieldCount > 1.99) {
+				// Lowest delta (most consistent field count across rows) wins; average
+				// field count only breaks ties between equally consistent delimiters.
+				if (avgFieldCount > 1.99 && (typeof bestDelta === 'undefined'
+					|| delta < bestDelta
+					|| (delta === bestDelta && avgFieldCount > maxFieldCount))) {
 					bestDelta = delta;
 					bestDelim = delim;
 					maxFieldCount = avgFieldCount;

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1352,6 +1352,20 @@ var PARSE_TESTS = [
 		}
 	},
 	{
+		description: "Delimiter is guessed correctly when a quoted field holds newlines and other delimiter characters",
+		notes: "A wrong delimiter that splits the quoted field into many pieces can report a higher average field count; the most consistent delimiter (lowest delta) should still win. See issue #1077",
+		input: 'id;title;data\r\n1;row one;"{\n  ""a"": 1,\n  ""b"": 2,\n  ""c"": 3,\n  ""d"": 4\n}"\r\n2;row two;"{\n  ""a"": 1,\n  ""b"": 2,\n  ""c"": 3,\n  ""d"": 4\n}"',
+		config: {},
+		expected: {
+			data: [
+				['id', 'title', 'data'],
+				['1', 'row one', '{\n  "a": 1,\n  "b": 2,\n  "c": 3,\n  "d": 4\n}'],
+				['2', 'row two', '{\n  "a": 1,\n  "b": 2,\n  "c": 3,\n  "d": 4\n}']
+			],
+			errors: []
+		}
+	},
+	{
 		description: "Single quote as quote character",
 		notes: "Must parse correctly when single quote is specified as a quote character",
 		input: "a,b,'c,d'",


### PR DESCRIPTION
Fixes #1077.

`guessDelimiter` picks `,` over `;` for a `;`-separated file once a quoted field holds a few embedded newlines (the two files in #1077 differ only by that). The real fields never start with a quote, so trialling `,` never enters quote mode, the JSON's commas shatter the row, and `,`'s average field count balloons past the correct `;`. The old rule needed a candidate to beat both the lowest delta and the highest average, so the perfectly consistent `;` (delta 0) lost.

Now row-to-row consistency is primary and average field count only breaks ties, so the most consistent delimiter wins. One call for you: strictly-primary delta is the contained fix, but a consistent-but-sparse delimiter could in theory beat a ragged correct one. Nothing in the suite hits that and I couldn't build a realistic file that does, happy to weight field count back in if you'd rather. Same bug is in the v6 branch (`v6-todo`) if you want it there.

Regression test added in `tests/test-cases.js` (fails on master, passes here); lint and test-node green. Left `papaparse.min.js` alone since that looks like a release step.