### PR TITLE
fix(unparse): don't force quotes on literal " when quoteChar is customized

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -296,6 +296,17 @@ License: MIT
 
 		var quoteCharRegex = new RegExp(escapeRegExp(_quoteChar), 'g');
 
+		/**
+		 * Characters that force a field to be wrapped in quotes. Papa.BAD_DELIMITERS
+		 * includes the default quote character ("), which is only structural when it
+		 * is actually the configured quoteChar. A custom quoteChar is handled by the
+		 * dedicated _quoteChar check in safe(), so a literal " must not force quoting
+		 * when quoteChar has been customized.
+		 */
+		var _quoteForcingChars = _quoteChar === '"'
+			? Papa.BAD_DELIMITERS
+			: ['\r', '\n', Papa.BYTE_ORDER_MARK];
+
 		if (typeof _input === 'string')
 			_input = JSON.parse(_input);
 
@@ -469,7 +480,7 @@ License: MIT
 							|| _quotes === true
 							|| (typeof _quotes === 'function' && _quotes(str, col))
 							|| (Array.isArray(_quotes) && _quotes[col])
-							|| hasAny(escapedQuoteStr, Papa.BAD_DELIMITERS)
+							|| hasAny(escapedQuoteStr, _quoteForcingChars)
 							|| escapedQuoteStr.indexOf(_delimiter) > -1
 							|| strValue.indexOf(_quoteChar) > -1
 							|| escapedQuoteStr.charAt(0) === ' '

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -2073,6 +2073,13 @@ var UNPARSE_TESTS = [
 		expected: 'foo,"""quoted"""'
 	},
 	{
+		description: "Custom quoteChar does not quote a field containing the default quote character",
+		notes: "Issue #1035: a literal double-quote must not force quoting when quoteChar is customized",
+		input: [['x"y']],
+		config: {quoteChar: '@', delimiter: ' '},
+		expected: 'x"y'
+	},
+	{
 		description: "Custom quoteChar escapes and quotes embedded quoteChar (no escapeChar)",
 		input: [['a', 'x+y']],
 		config: {header: false, quoteChar: '+'},


### PR DESCRIPTION
## Problem

`safe()` used `Papa.BAD_DELIMITERS` to decide whether a field needs quoting. That list contains the default quote character (`"`), so any field holding a literal double-quote was wrapped in quotes even when a custom `quoteChar` was configured — e.g. `unparse([['x"y']], { quoteChar: '@', delimiter: ' ' })` returned `@x"y@` instead of `x"y`. The configured `quoteChar` is already handled by the dedicated `_quoteChar` check, so a literal `"` must only force quoting when `"` is actually the `quoteChar`.

## Fix

Introduce `_quoteForcingChars`: when `quoteChar` is the default `"`, it stays `Papa.BAD_DELIMITERS`; when `quoteChar` is customized, the default `"` is dropped from the forcing set (leaving `\r`, `\n`, and the BYTE_ORDER_MARK). `safe()` now checks against `_quoteForcingChars` instead of `Papa.BAD_DELIMITERS`. Structural quoting for the configured `quoteChar` remains handled by the existing `_quoteChar` check.

## Testing

Added an unparse test case covering issue #1035: a field containing the default `"` with a custom `quoteChar` (`@`) and space delimiter is no longer force-quoted.

Closes #1035
