### PR TITLE
Fix: duplicate-header dedupe corrupts data rows under streaming backpressure

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1113,6 +1113,18 @@ License: MIT
 			if (_config.preview && _config.header)
 				parserConfig.preview++;	// to compensate for header row
 
+			// Once the header row has been consumed (_fields populated) it must
+			// never be re-derived. A fresh low-level Parser is created for every
+			// chunk AND every pause/resume, so the per-Parser `headerParsed` flag
+			// and the `!baseIndex` heuristic are not sufficient on their own: a
+			// pause during the first chunk (backpressure from a slow consumer)
+			// returns from parseChunk before `_baseIndex` advances past 0, so the
+			// resumed parse would otherwise treat the next DATA row as a header
+			// and apply duplicate-header suffixing (e.g. "" -> "_1") to its
+			// values. Gating on whether the header was already parsed prevents
+			// that corruption.
+			parserConfig.headerAlreadyParsed = _config.header && _fields.length > 0;
+
 			_input = input;
 			_parser = new Parser(parserConfig);
 			_results = _parser.parse(_input, baseIndex, ignoreLastRow);
@@ -1747,7 +1759,7 @@ License: MIT
 			/** Returns an object with the results, errors, and meta. */
 			function returnable(stopped)
 			{
-				if (config.header && !baseIndex && data.length && !headerParsed)
+				if (config.header && !config.headerAlreadyParsed && !baseIndex && data.length && !headerParsed)
 				{
 					const result = data[0];
 					const headerCount = Object.create(null); // To track the count of each base header

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -179,6 +179,58 @@ describe('PapaParse', function() {
 		});
 	});
 
+	it('does not leak duplicate-header suffixes into data rows under backpressure (header: true)', function(done) {
+		// Regression test: a slow downstream consumer applies backpressure, so
+		// the piped stream pauses/resumes during the first chunk. The duplicate-
+		// header dedupe must only ever apply to the true header row; duplicate or
+		// blank cell values in DATA rows must not gain "_1"/"_2" suffixes.
+		var numRows = 500;
+		var input = 'email,middle_name,address2,country\n';
+		for (var i = 0; i < numRows; i++) {
+			input += 'user' + i + '@example.com,,,US\n';
+		}
+		var rows = [];
+		var csvStream = Papa.parse(Papa.NODE_STREAM_INPUT, {header: true});
+		csvStream.on('error', done);
+		csvStream.on('end', function() {
+			assert.equal(rows.length, numRows);
+			var corrupted = rows.filter(function(row) {
+				return Object.keys(row).some(function(key) {
+					return typeof row[key] === 'string' && /_\d+$/.test(row[key]);
+				});
+			});
+			assert.deepEqual(corrupted, []);
+			rows.forEach(function(row) {
+				assert.equal(row.middle_name, '');
+				assert.equal(row.address2, '');
+				assert.equal(row.country, 'US');
+				assert.ok(!('__parsed_extra' in row));
+			});
+			done();
+		});
+		// Slow reader: yield to the event loop between rows so the transform's
+		// readable buffer fills past its highWaterMark and PapaParse hits
+		// backpressure (pause/resume) mid-first-chunk.
+		var pump = function() {
+			var chunk = csvStream.read();
+			if (chunk === null) {
+				csvStream.once('readable', pump);
+				return;
+			}
+			rows.push(chunk);
+			setImmediate(pump);
+		};
+		csvStream.once('readable', pump);
+		csvStream.end(Buffer.from(input, 'utf8'));
+	});
+
+	it('still renames genuinely duplicate header columns', function() {
+		var result = Papa.parse('email,email,name\na@x.com,b@x.com,alice', {header: true});
+		assert.deepEqual(result.data, [
+			{ email: 'a@x.com', email_1: 'b@x.com', name: 'alice' }
+		]);
+	});
+
 	it('should support pausing and resuming on same tick when streaming', function(done) {
 		var rows = [];
 		Papa.parse(fs.createReadStream(__dirname + '/long-sample.csv', 'utf8'), {


### PR DESCRIPTION
## Problem

When parsing a stream with `header: true` and a **slow / backpressured** consumer, PapaParse's duplicate-header dedupe (`email` → `email_1`, `""` → `_1`) is wrongly applied to **data rows**. Any data row with duplicate or blank cell values gets `_1`/`_2` suffixes silently written into its values.

### Reproduction (on current `master`)

```js
const Papa = require('papaparse');
let input = 'email,middle_name,address2,country\n';
for (let i = 0; i < 500; i++) input += `user${i}@example.com,,,US\n`;

const stream = Papa.parse(Papa.NODE_STREAM_INPUT, { header: true });
const rows = [];
const pump = () => {                       // slow reader => backpressure
  const row = stream.read();
  if (row === null) return void stream.once('readable', pump);
  rows.push(row);
  setImmediate(pump);
};
stream.once('readable', pump);
stream.on('end', () =>
  console.log(rows.filter(r => r.address2 === '_1').length)); // 484 — should be 0
stream.end(Buffer.from(input));
```

Every empty `address2` becomes `_1` (~484 of 500 rows here).

## Root cause

The dedupe runs in the low-level parser's `returnable()`, guarded by `!baseIndex` and a per-`Parser` `headerParsed` flag. But a fresh `Parser` (with `headerParsed` reset) is created for **every chunk and every pause/resume**. Under backpressure the streamer pauses mid-first-chunk and returns before `_baseIndex` advances past `0`; on resume, `!baseIndex && !headerParsed` is true again, so the dedupe re-fires — treating the next **data** row as a header and suffixing its duplicate/blank values.

## Fix

Gate the dedupe on whether the header has already been consumed. `_fields` is populated once and persists at the `ParserHandle` level across chunks and pause/resume (unlike the per-`Parser` `headerParsed`). `ParserHandle` sets `parserConfig.headerAlreadyParsed = _config.header && _fields.length > 0`, and `returnable()` also checks `!config.headerAlreadyParsed`. Legitimate renaming of a genuinely duplicated header row is unchanged.

## Test

Adds a Node streaming regression test in `tests/node-tests.js` that reproduces the corruption under backpressure (fails before this change, passes after) and asserts genuine duplicate-header renaming still works.

## Notes

Small and self-contained. Related to #1017 (duplicate headers across chunks) and #129 / #1083, but this targets specifically the pause/resume re-fire.
