### PR TITLE
Fix multi-byte characters corrupted at a chunk boundary

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -774,6 +774,7 @@ License: MIT
 		var queue = [];
 		var parseOnData = true;
 		var streamHasEnded = false;
+		var decoder = null;
 
 		this.pause = function()
 		{
@@ -816,11 +817,29 @@ License: MIT
 			}
 		};
 
+		// A chunk boundary can fall inside a multi-byte character, so the bytes
+		// cannot be decoded one chunk at a time: an incomplete sequence has to be
+		// held back until the next chunk completes it, or both halves decode to
+		// U+FFFD and the field is silently corrupted.
+		this._decode = function(chunk)
+		{
+			if (typeof PAPA_BROWSER_CONTEXT === 'undefined')
+			{
+				if (decoder === null)
+				{
+					var StringDecoder = require('string_decoder').StringDecoder;
+					decoder = new StringDecoder(this._config.encoding || 'utf8');
+				}
+				return decoder.write(chunk);
+			}
+			return chunk.toString(this._config.encoding);
+		};
+
 		this._streamData = bindFunction(function(chunk)
 		{
 			try
 			{
-				queue.push(typeof chunk === 'string' ? chunk : chunk.toString(this._config.encoding));
+				queue.push(typeof chunk === 'string' ? chunk : this._decode(chunk));
 
 				if (parseOnData)
 				{
@@ -845,7 +864,9 @@ License: MIT
 		{
 			this._streamCleanUp();
 			streamHasEnded = true;
-			this._streamData('');
+			// Flushing the decoder also delivers the empty sentinel chunk the
+			// finish check looks for.
+			this._streamData(decoder === null ? '' : decoder.end());
 		}, this);
 
 		this._streamCleanUp = bindFunction(function()

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -4,6 +4,7 @@ var Papa = require("../papaparse.js");
 
 var fs = require('fs');
 var assert = require('assert');
+var Readable = require('stream').Readable;
 var longSampleRawCsv = fs.readFileSync(__dirname + '/long-sample.csv', 'utf8');
 var utf8BomSampleRawCsv = fs.readFileSync(__dirname + '/utf-8-bom-sample.csv', 'utf8');
 
@@ -36,6 +37,17 @@ function assertLongSampleParsedCorrectly(parsedCsv) {
 		"cursor": 1209
 	});
 	assert.equal(parsedCsv.errors.length, 0);
+}
+
+// A readable stream that delivers exactly the buffers it is given, so the chunk
+// boundaries are fixed rather than left to the file system.
+function bufferStream(buffers) {
+	var i = 0;
+	return new Readable({
+		read: function() {
+			this.push(i < buffers.length ? buffers[i++] : null);
+		}
+	});
 }
 
 describe('PapaParse', function() {
@@ -285,6 +297,25 @@ describe('PapaParse', function() {
 			},
 			error: function(err) {
 				assert.deepEqual(err, expectedError);
+				done();
+			}
+		});
+	});
+
+	it('handles a multi-byte character split across a chunk boundary', function(done) {
+		// Two CJK ideographs, three UTF-8 bytes each, built from code points so
+		// this file stays pure ASCII.
+		var cjk = String.fromCharCode(0x4e2d, 0x6587);
+		var bytes = Buffer.from('a,b\n1,' + cjk + '\n2,x\n', 'utf8');
+		var split = bytes.indexOf(0xe4) + 1;	// one byte into the first ideograph
+		var rows = [];
+		Papa.parse(bufferStream([bytes.subarray(0, split), bytes.subarray(split)]), {
+			step: function(results) {
+				rows.push(results.data);
+			},
+			error: done,
+			complete: function() {
+				assert.deepEqual(rows, [['a', 'b'], ['1', cjk], ['2', 'x']]);
 				done();
 			}
 		});


### PR DESCRIPTION
`ReadableStreamStreamer` decodes each incoming `Buffer` on its own:

```js
queue.push(typeof chunk === 'string' ? chunk : chunk.toString(this._config.encoding));
```

A UTF-8 sequence that straddles a chunk boundary is therefore split across two independent
`toString` calls and both halves come back as U+FFFD. The row count and the error list stay
clean, so nothing signals the corruption.

Minimal reproduction:

```js
var Papa = require('./papaparse.js');
var Readable = require('stream').Readable;

var cjk = String.fromCharCode(0x4e2d, 0x6587);    // two CJK ideographs, 3 UTF-8 bytes each
var bytes = Buffer.from('a,b\n1,' + cjk + '\n2,x\n', 'utf8');
var split = bytes.indexOf(0xe4) + 1;              // one byte into the first ideograph
var chunks = [bytes.subarray(0, split), bytes.subarray(split)], i = 0;
var source = new Readable({read: function() { this.push(i < chunks.length ? chunks[i++] : null); }});

Papa.parse(source, {
    step: function(r) { console.log(JSON.stringify(r.data)); }
});
// ["a","b"]
// ["1","��文"]     <- expected ["1","中文"]
// ["2","x"]
```

**The fix.** Hold one `string_decoder.StringDecoder` for the life of the stream so an
incomplete sequence is carried over to the next chunk, and flush it in `_streamEnd`. The
decode path sits behind the existing `typeof PAPA_BROWSER_CONTEXT === 'undefined'` guard the
file already uses in three places, so the browser bundle keeps calling `Buffer#toString`.
After `npm run build`, `grep -c string_decoder papaparse.min.js` returns 0, so the browser
bundle is unaffected in size and behaviour. `papaparse.min.js` is not included in this PR.

**The test.** `tests/node-tests.js`, "handles a multi-byte character split across a chunk
boundary". It feeds a two-buffer stream split one byte into a three-byte character and
asserts all three rows parse exactly.

Reported in #1132.