### PR TITLE
Fix line ending guessed from a truncated chunk

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1019,13 +1019,35 @@ License: MIT
 		this.parse = function(input, baseIndex, ignoreLastRow)
 		{
 			var quoteChar = _config.quoteChar || '"';
-			if (!_config.newline)
-				_config.newline = this.guessLineEndings(input, quoteChar);
+
+			// When the input is one chunk of a longer stream its tail is an
+			// incomplete row, and it can even stop between the CR and the LF of a
+			// CRLF pair. Both guesses below are cached for the whole file, so a
+			// guess taken from that tail silently corrupts every later row. Guess
+			// from complete lines only, and cache the line ending only once the
+			// sample actually contained one.
+			var completeSample = ignoreLastRow ? completeLines(input) : input;
+			var guessSample = completeSample;
+			if (guessSample === null)
+			{
+				// Nothing in this chunk is a line we can trust. Guess from it
+				// anyway, but never from a trailing CR whose LF may be in the
+				// next chunk, or the guess becomes '\r' and the row is cut in two.
+				guessSample = input.charAt(input.length - 1) === '\r' ? input.slice(0, -1) : input;
+			}
+
+			var newline = _config.newline;
+			if (!newline)
+			{
+				newline = this.guessLineEndings(guessSample, quoteChar);
+				if (completeSample !== null)
+					_config.newline = newline;
+			}
 
 			_delimiterError = false;
 			if (!_config.delimiter)
 			{
-				var delimGuess = guessDelimiter(input, _config.newline, _config.skipEmptyLines, _config.comments, _config.delimitersToGuess);
+				var delimGuess = guessDelimiter(guessSample, newline, _config.skipEmptyLines, _config.comments, _config.delimitersToGuess);
 				if (delimGuess.successful)
 					_config.delimiter = delimGuess.bestDelimiter;
 				else
@@ -1046,6 +1068,9 @@ License: MIT
 			parserConfig.header = needsHeaderRow();
 			if (_config.preview && _config.header)
 				parserConfig.preview++;	// to compensate for header row
+
+			// Not _config.newline: that is only set once a guess could be trusted.
+			parserConfig.newline = newline;
 
 			_input = input;
 			_parser = new Parser(parserConfig);
@@ -1340,6 +1365,20 @@ License: MIT
 			}
 			_results.errors.push(error);
 		}
+	}
+
+	/**
+	 * The leading part of input that is known to consist of whole lines, or null
+	 * when input holds no line ending that is certainly complete. A trailing CR is
+	 * never trusted: the LF that would pair with it may be in the next chunk.
+	 */
+	function completeLines(input)
+	{
+		var lastLf = input.lastIndexOf('\n');
+		if (lastLf !== -1)
+			return input.substring(0, lastLf + 1);
+		var lastCr = input.length > 1 ? input.lastIndexOf('\r', input.length - 2) : -1;
+		return lastCr === -1 ? null : input.substring(0, lastCr + 1);
 	}
 
 	/** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions */

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -2962,6 +2962,56 @@ var CUSTOM_TESTS = [
 			});
 		}
 	},
+	{
+		description: "Line ending is not guessed from a chunk that holds no complete line",
+		expected: [{aaaa: '1', bbbb: '2', cccc: '3', dddd: '4'}, {aaaa: '5', bbbb: '6', cccc: '7', dddd: '8'}],
+		run: function(callback) {
+			var rows = [];
+			// The header row is longer than a chunk, so the first chunk contains
+			// no line break at all and the guess used to be cached as '\n'.
+			Papa.parse('aaaa,bbbb,cccc,dddd\r\n1,2,3,4\r\n5,6,7,8', {
+				header: true,
+				chunkSize: 12,
+				step: function(results) {
+					rows.push(results.data);
+				},
+				complete: function() {
+					callback(rows);
+				}
+			});
+		}
+	},
+	{
+		description: "A CRLF file parses the same at every chunk size",
+		timeout: 10000,
+		expected: [],
+		run: function(callback) {
+			var csv = 'aaaa,bbbb,cccc,dddd\r\n1,2,3,4\r\n5,6,7,8\r\n';
+			var expected = JSON.stringify(Papa.parse(csv).data);
+			var sizes = [];
+			for (var i = 1; i <= csv.length; i++)
+				sizes.push(i);
+			var disagreed = [];
+			(function next() {
+				if (!sizes.length)
+					return callback(disagreed);
+				var chunkSize = sizes.shift();
+				var rows = [];
+				Papa.parse(csv, {
+					chunkSize: chunkSize,
+					step: function(results) {
+						rows.push(results.data);
+					},
+					complete: function() {
+						if (JSON.stringify(rows) !== expected)
+							disagreed.push(chunkSize);
+						// A string parse is synchronous, so unwind between sizes.
+						setTimeout(next, 0);
+					}
+				});
+			})();
+		}
+	},
 ];
 
 describe('Custom Tests', function() {


### PR DESCRIPTION
`ParserHandle.parse` guesses the line ending from whatever the current chunk happens to hold
and then caches it on `_config.newline` for the whole file:

```js
if (!_config.newline)
    _config.newline = this.guessLineEndings(input, quoteChar);
```

When the first chunk stops before any line break, `guessLineEndings` sees no CR and returns
`'\n'`. That is then used for the rest of a CRLF file, so every row comes back with a stray CR
on its last field and the last header key keeps a CR too. There is no error and the row count
is correct. The same guess also misfires when a chunk ends between the CR and the LF of a CRLF
pair, which splits the row instead.

Minimal reproduction, header row longer than the chunk:

```js
Papa.parse('aaaa,bbbb,cccc,dddd\r\n1,2,3,4\r\n5,6,7,8', {
    header: true,
    chunkSize: 12,
    step: function(r) { console.log(JSON.stringify(r.data)); }
});
// {"aaaa":"1","bbbb":"2","cccc":"3","dddd\r":"4\r"}
// {"aaaa":"5","bbbb":"6","cccc":"7","dddd\r":"8"}
```

**The fix.** Feed both guessers only the leading part of the chunk that is known to be whole
lines, and cache the line ending only once that sample actually contained one. A trailing CR is
never trusted, because the LF that would pair with it may be in the next chunk. The delimiter
guess, which is cached the same way, gets the same sample.

Swept over a small CRLF corpus, comparing a chunked parse against the whole-input parse of the
same text at every chunk size from 1 to the input length:

| corpus | master | branch |
|---|---|---|
| CRLF plain (39 chars) | 21 of 39 chunk sizes disagree | 0 |
| CR-only line endings (36) | 19 of 36 | 0 |
| CRLF with quoted fields (57) | 7 of 57 | 0 |
| CRLF, no trailing newline (28) | 16 of 28 | 0 |
| CRLF, long header (71) | 51 of 71 | 0 |
| LF plain (36) | 0 | 0 |
| LF with quoted fields (52) | 0 | 0 |

**The tests.** `tests/test-cases.js`:

- "Line ending is not guessed from a chunk that holds no complete line", the concrete symptom
  above.
- "A CRLF file parses the same at every chunk size", which sweeps chunk sizes 1 to 39 over a
  CRLF file and asserts none disagrees with the whole-input parse. This is the one that covers
  a boundary landing between the CR and the LF.

Reported in #1132.

**Red-green evidence:**

```
$ git checkout master -- papaparse.js
$ npx mocha tests/test-cases.js --grep "chunk that holds no complete line|CRLF file parses the same"

  1) Custom Tests
       Line ending is not guessed from a chunk that holds no complete line:

      AssertionError: expected [ Array(2) ] to deeply equal [ Array(2) ]
      + expected - actual
           "cccc": "3"
      -    "dddd": "4\r"
      +    "dddd": "4"

  2) Custom Tests
       A CRLF file parses the same at every chunk size:

      Uncaught AssertionError: expected [ Array(21) ] to deeply equal []
      + expected - actual
      -[ 1 2 3 4 5 6 7 8 9 10 11 12 13 14 ... ]
```

```
$ git checkout fix/line-ending-guess -- papaparse.js
$ npx mocha tests/test-cases.js --grep "chunk that holds no complete line|CRLF file parses the same"

  Custom Tests
    [pass] Line ending is not guessed from a chunk that holds no complete line
    [pass] A CRLF file parses the same at every chunk size (595ms)

  2 passing (604ms)
```

Suite and lint on the branch:

```
$ npm run lint      # exit 0, no output
$ npm run test-node
  249 passing (32s)
  23 pending
  1 failing         # the pre-existing bug #636 timeout, unchanged
```