### PR TITLE
Fix header de-duplication re-running on every resumed row

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1110,6 +1110,14 @@ License: MIT
 			}
 
 			var parserConfig = copy(_config);
+			// The core parser reads the header row out of the first rows it sees
+			// and decides "first" from baseIndex, which does not advance while the
+			// caller is paused. On every resume it therefore treated the next data
+			// row as a header row and rewrote its duplicate and empty values in
+			// place. The handle already knows whether the header has been
+			// consumed, so tell the parser instead of letting it guess from an
+			// offset. (issues #985, #998)
+			parserConfig.header = needsHeaderRow();
 			if (_config.preview && _config.header)
 				parserConfig.preview++;	// to compensate for header row
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -2312,6 +2312,48 @@ var CUSTOM_TESTS = [
 		}
 	},
 	{
+		description: "Duplicate values in a data row are not renamed after resume (Regression Test for Issue #998)",
+		expected: [
+			{c1: 'foo, bar', c2: 'foo, bar', c3: 'v1'},
+			{c1: 'foo, bar', c2: 'foo, bar', c3: 'v2'}
+		],
+		run: function(callback) {
+			var rows = [];
+			Papa.parse('c1,c2,c3\n"foo, bar","foo, bar",v1\n"foo, bar","foo, bar",v2\n', {
+				header: true,
+				step: function(results, parser) {
+					parser.pause();
+					rows.push(results.data);
+					parser.resume();
+				},
+				complete: function() {
+					callback(rows);
+				}
+			});
+		}
+	},
+	{
+		description: "Empty trailing fields stay empty after resume (Regression Test for Issue #985)",
+		expected: [
+			{a: '1', b: 'x', c: '', d: ''},
+			{a: '2', b: 'y', c: '', d: ''}
+		],
+		run: function(callback) {
+			var rows = [];
+			Papa.parse('a,b,c,d\n1,x,,\n2,y,,\n', {
+				header: true,
+				step: function(results, parser) {
+					parser.pause();
+					rows.push(results.data);
+					parser.resume();
+				},
+				complete: function() {
+					callback(rows);
+				}
+			});
+		}
+	},
+	{
 		description: "Complete is called with all results if neither step nor chunk is defined",
 		expected: [['A', 'b', 'c'], ['d', 'E', 'f'], ['G', 'h', 'i']],
 		disabled: !FILES_ENABLED,


### PR DESCRIPTION
The core parser decides whether the rows it is holding are the header row from `baseIndex`:

```js
if (config.header && !baseIndex && data.length && !headerParsed)
```

`baseIndex` does not advance while the caller is paused: `ChunkStreamer.parseChunk` returns at
the `this._handle.paused()` check before it reaches the `this._baseIndex = lastIndex`
bookkeeping. A fresh `Parser` is built for every resumed call, so `headerParsed` resets too.
Every resumed row is therefore de-duplicated as if it were a header row and rewritten in place.

Minimal reproduction:

```js
Papa.parse('c1,c2,c3\n"foo, bar","foo, bar",v1\n"foo, bar","foo, bar",v2\n', {
    header: true,
    step: function(r, parser) { parser.pause(); console.log(JSON.stringify(r.data)); parser.resume(); }
});
// {"c1":"foo, bar","c2":"foo, bar","c3":"v1"}
// {"c1":"foo, bar","c2":"foo, bar_1","c3":"v2"}     <- rewritten, plus a console.warn per row
```

and the same root cause on empty trailing fields, since empty strings look like duplicate
headers to the de-duplicator:

```js
Papa.parse('a,b,c,d\n1,x,,\n2,y,,\n', {
    header: true,
    step: function(r, parser) { parser.pause(); console.log(JSON.stringify(r.data)); parser.resume(); }
});
// {"a":"1","b":"x","c":"","d":""}
// {"a":"2","b":"y","c":"","d":"_1"}                 <- should be ""
```

This is issue #998 and the renaming half of issue #985.

**The fix.** The handle already tracks whether it has captured the header; `needsHeaderRow()`
is what it uses to drive `fillHeaderFields`. Pass that to the parser through `parserConfig`
instead of letting the parser infer it from an offset. One line, and `config.header` is not
read anywhere else in `Parser`.

Note: this moves the decision about when the core parser looks for a header row from the
parser to the handle. If #1100 wants that ownership drawn differently, say so and I will
rework it.

**The tests.** `tests/test-cases.js`, "Duplicate values in a data row are not renamed after
resume (Regression Test for Issue #998)" and "Empty trailing fields stay empty after resume
(Regression Test for Issue #985)".

Reported in #1132.

**Red-green evidence:**

```
$ git checkout master -- papaparse.js
$ npx mocha tests/test-cases.js --grep "Issue #998|Issue #985"

Duplicate headers found and renamed.
Duplicate headers found and renamed.

  1) Custom Tests
       Duplicate values in a data row are not renamed after resume (Regression Test for Issue #998):

      Uncaught AssertionError: expected [ { c1: 'foo, bar', ...(2) }, ...(1) ] to deeply equal [ { c1: 'foo, bar', ...(2) }, ...(1) ]
      + expected - actual
      -    "c2": "foo, bar_1"
      +    "c2": "foo, bar"

  2) Custom Tests
       Empty trailing fields stay empty after resume (Regression Test for Issue #985):

      Uncaught AssertionError: expected [ ...(2) ] to deeply equal [ ...(2) ]
      + expected - actual
      -    "d": "_1"
      +    "d": ""
```

```
$ git checkout fix/header-dedupe-on-resume -- papaparse.js
$ npx mocha tests/test-cases.js --grep "Issue #998|Issue #985"

  Custom Tests
    [pass] Duplicate values in a data row are not renamed after resume (Regression Test for Issue #998)
    [pass] Empty trailing fields stay empty after resume (Regression Test for Issue #985)

  2 passing (72ms)
```

Suite and lint on the branch:

```
$ npm run lint      # exit 0, no output
$ npm run test-node
  249 passing (32s)
  23 pending
  1 failing         # the pre-existing bug #636 timeout, unchanged
```