### PR TITLE
fix(unparse): serialize Dates with toISOString() instead of a fixed-width slice

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -453,7 +453,13 @@ License: MIT
 				return '';
 
 			if (str.constructor === Date)
-				return JSON.stringify(str).slice(1, 25);
+			{
+				// An invalid Date has no ISO representation; JSON.stringify() turns it
+				// into null, which we write out the same way as any other null value.
+				if (isNaN(str.getTime()))
+					return '';
+				return str.toISOString();
+			}
 
 			var needsQuotes = false;
 

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -2011,6 +2011,16 @@ var UNPARSE_TESTS = [
 		expected: 'date,not a date\r\n2018-05-04T21:08:03.269Z,16\r\n2018-05-08T15:20:22.000Z,32'
 	},
 	{
+		description: "Invalid Date objects are exported as an empty field",
+		input: [{date: new Date("not a date"), "not a date": 16}],
+		expected: 'date,not a date\r\n,16'
+	},
+	{
+		description: "Date objects with an expanded year are exported in its full ISO representation",
+		input: [{date: new Date("+010000-01-01T00:00:00.000Z"), "not a date": 16}],
+		expected: 'date,not a date\r\n+010000-01-01T00:00:00.000Z,16'
+	},
+	{
 		description: "Returns empty rows when empty rows are passed and skipEmptyLines is false",
 		input: [[null, ' '], [], ['1', '2']],
 		config: {skipEmptyLines: false},


### PR DESCRIPTION
## Problem

`Papa.unparse()` writes the literal text `ull` into the CSV when a value is an invalid `Date`.

Against the published release (`papaparse@5.5.3`, fresh `npm install`):

```
$ node -e "const Papa=require('papaparse');
console.log(JSON.stringify(Papa.unparse([{when: new Date('not a date'), who:'alice'}])))"
"when,who\r\null,alice"
```

The second row is `ull,alice`.

This is easy to hit in practice: any export that does `new Date(row.timestamp)` on data
where `timestamp` can be null, empty or malformed produces an invalid `Date`, and the
resulting CSV silently contains the string `ull` instead of an empty cell.

The same expression also truncates `Date`s whose year falls outside `0000`-`9999`:

```
$ node -e "const Papa=require('papaparse');
console.log(JSON.stringify(Papa.unparse([[new Date('+010000-01-01T00:00:00.000Z')]])))"
"+010000-01-01T00:00:00.0"
```

The trailing `00Z` is cut off, so the timestamp is no longer a valid ISO 8601 string.

## Root cause

`papaparse.js:455` (in `safe()`):

```js
if (str.constructor === Date)
    return JSON.stringify(str).slice(1, 25);
```

The `slice(1, 25)` assumes `JSON.stringify(date)` is always a 26-character string: a
quote, a 24-character ISO timestamp, and a closing quote. Two inputs break that:

* **Invalid `Date`** — `Date.prototype.toJSON` returns `null` for a non-finite date, so
  `JSON.stringify()` yields the 4-character string `null`. `slice(1, 25)` turns that into
  `ull`.
* **Expanded year** — for years outside `0000`-`9999`, `toISOString()` emits the
  expanded-year form (`±YYYYYY-MM-DDTHH:mm:ss.sssZ`, 27 characters), so the JSON string is
  29 characters and `slice(1, 25)` cuts the timestamp short.

The `slice(1, 25)` was only ever a way to strip the quotes that `JSON.stringify()` adds
(introduced in 757dc37 / #506, whose stated goal was "Dates serialize to ISO format",
consistent with `JSON.stringify`). Calling `toISOString()` directly expresses that intent
without the fixed-width assumption.

## Fix

```js
if (str.constructor === Date)
{
    // An invalid Date has no ISO representation; JSON.stringify() turns it
    // into null, which we write out the same way as any other null value.
    if (isNaN(str.getTime()))
        return '';
    return str.toISOString();
}
```

`toISOString()` throws a `RangeError` on a non-finite date, so the invalid case is handled
explicitly. Writing an empty field for it is the choice that stays consistent with the
surrounding code and with the original design goal: `safe()` already returns `''` for
`null` and `undefined` two lines above, and `JSON.stringify()` — the behaviour #506 set out
to match — represents an invalid `Date` as `null`.

For every in-range valid `Date` the output is byte-identical to before, because
`JSON.stringify(date).slice(1, 25)` and `date.toISOString()` are the same 24 characters
there. The existing `"Date objects are exported in its ISO representation"` test passes
unchanged.

The one case where output does change for a *valid* `Date` is a monkeypatched `toJSON`
(the occasional trick for emitting local-time ISO): the old code went through
`JSON.stringify()` and so honoured the patch, the new code calls `toISOString()` and
ignores it. That path was already broken before this change — a local-time ISO string is
29 characters, so `slice(1, 25)` emitted `2020-06-01T14:00:00.000+`, i.e. a truncated
timestamp with a dangling `+`. Only a patch returning exactly 24 characters was intact
before and changes now.

## Before / after

Baseline is the current `master` source restored with
`git show HEAD~1:papaparse.js > papaparse.js` (verified: `grep -c toISOString papaparse.js`
→ `0`), with the two new test cases in place.

**Before (2 failing):**

```
  1) Unparse Tests
       Invalid Date objects are exported as an empty field:

      AssertionError: expected 'date,not a date\r\null,16' to equal 'date,not a date\r\n,16'
      + expected - actual

       date,not a date
      -ull,16
      +,16

  2) Unparse Tests
       Date objects with an expanded year are exported in its full ISO representation:

      AssertionError: expected 'date,not a date\r\n+010000-01-01T00:0…' to equal 'date,not a date\r\n+010000-01-01T00:0…'
      + expected - actual

       date,not a date
      -+010000-01-01T00:00:00.0,16
      ++010000-01-01T00:00:00.000Z,16

  248 passing (9s)
  23 pending
  2 failing
```

**After:**

```
    ✓ Invalid Date objects are exported as an empty field
    ✓ Date objects with an expanded year are exported in its full ISO representation

  250 passing (9s)
  23 pending
```

`npm run lint` is clean and `npm run build` succeeds (the regenerated `papaparse.min.js` is
deliberately not committed, matching #1124 and #1128, which touch only `papaparse.js` and
`tests/test-cases.js`).

## Tests

Two cases added to `UNPARSE_TESTS`, next to the existing Date test:

* `Invalid Date objects are exported as an empty field`
* `Date objects with an expanded year are exported in its full ISO representation`

## Other checks

* **Output identity for valid `Date`s.** 500 000 random in-range timestamps compared at the
  expression level (`JSON.stringify(d).slice(1, 25)` vs `d.toISOString()`) and 70 000 run
  through `unparse()` across 7 option sets (default, `quotes: true`, `delimiter: ';'`,
  `quoteChar: "'"`, `newline: '\n'`, `escapeFormulae: true`, `header: false`): 0 byte
  differences, with exact equality at both boundaries (year `0000` and `9999-12-31T23:59:59.999Z`).
  The only outputs that change are the two buggy classes above.
* **Round-trip invariant** (the one #506 introduced, `unparse(Date)` →
  `parse(dynamicTyping: true)` → `Date`): 50 000 random dates with four-digit years,
  0 round-trip failures and 0 value mismatches.
* **Performance**: not a regression. `unparse()` of 200 000 single-`Date` rows runs roughly
  40% faster, since one `JSON.stringify` allocation per cell is removed; the all-invalid-`Date`
  worst case is faster by more than an order of magnitude. Absolute milliseconds are
  machine-specific so I have left them out — this is not the point of the change, just
  confirmation that nothing got slower in either direction.
* **No new characters reach the CSV unquoted.** The `Date` branch returns before the
  quoting logic, as it did before. Over the same corpus the full character set emitted by
  `toISOString()` is `+-.0123456789:TZ`, and none of those are in `Papa.BAD_DELIMITERS`
  (`\r`, `\n`, `"`, BOM); the expanded-year form already began with `+` under the old code
  too, so nothing changes about which values are emitted unquoted.

## What I could not verify

* The browser suite (`npm run test-mocha-headless-chrome`) does not launch in my
  environment (`spawn Unknown system error -88` — the bundled Chromium is an x86 binary on
  an arm64 host). CI does not run it either (#1087), and both new cases live in
  `tests/test-cases.js`, which the Node suite executes in full.
* Whether an empty field or the string `Invalid Date` is the preferred output for an
  invalid `Date` is a judgement call. I picked the empty field for consistency with `null`
  and `undefined` and with `JSON.stringify`; happy to switch if you'd rather surface it.
* I ran `npm run lint && npm run test-node && npm run build` — the exact CI command — on a
  single Node version locally, not on the 20/22/24 matrix. The change only uses `isNaN()`,
  `Date.prototype.getTime()` and `Date.prototype.toISOString()`, so I do not expect any
  version sensitivity, but CI is the authority on that.
