### PR TITLE
Strip the UTF-8 BOM from streamed input, not just string input

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -422,6 +422,13 @@ License: MIT
 		this.parseChunk = function(chunk, isFakeChunk)
 		{
 			// First chunk pre-processing
+			// A byte order mark is an encoding artifact rather than data. String input
+			// is stripped in CsvToJson, but every other input reaches the parser through
+			// here, so strip it at the front of the stream too. Without this the mark
+			// stays inside the first field of the first row, where it is invisible.
+			if (this.isFirstChunk)
+				chunk = stripBom(chunk);
+
 			const skipFirstNLines = parseInt(this._config.skipFirstNLines) || 0;
 			if (this.isFirstChunk && skipFirstNLines > 0) {
 				let _newline = this._config.newline;

--- a/papaparse.js
+++ b/papaparse.js
@@ -145,7 +145,6 @@ License: MIT
 		}
 		else if (typeof _input === 'string')
 		{
-			_input = stripBom(_input);
 			if (_config.download)
 				streamer = new NetworkStreamer(_config);
 			else
@@ -422,9 +421,9 @@ License: MIT
 		this.parseChunk = function(chunk, isFakeChunk)
 		{
 			// First chunk pre-processing
-			// A byte order mark is an encoding artifact rather than data. String input
-			// is stripped in CsvToJson, but every other input reaches the parser through
-			// here, so strip it at the front of the stream too. Without this the mark
+			// A byte order mark is an encoding artifact rather than data. Every input
+			// type (string, stream, download, File) reaches the parser through here, so
+			// strip a leading mark once at the front of the stream. Without this the mark
 			// stays inside the first field of the first row, where it is invisible.
 			if (this.isFirstChunk)
 				chunk = stripBom(chunk);

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -299,4 +299,45 @@ describe('PapaParse', function() {
 			}
 		});
 	});
+
+	it('strips the utf-8 BOM from a piped stream', function(done) {
+		// The mark is only invisible: without stripping it, data[0][0] is '\ufeffA'
+		// rather than 'A', so the first field of the first row never compares equal.
+		// Only string input went through stripBom, and header:true hid it because the
+		// header is stripped separately.
+		var data = [];
+		var readStream = fs.createReadStream(__dirname + '/utf-8-bom-sample.csv', 'utf8');
+		var csvStream = readStream.pipe(Papa.parse(Papa.NODE_STREAM_INPUT));
+		csvStream.on('data', function(item) {
+			data.push(item);
+		});
+		csvStream.on('end', function() {
+			assert.deepEqual(data[0], ['A', 'B', 'C']);
+			assert.deepEqual(data[1], ['X', 'Y', 'Z']);
+			done();
+		});
+	});
+
+	it('strips the utf-8 BOM from a piped stream when header is true', function(done) {
+		var data = [];
+		var readStream = fs.createReadStream(__dirname + '/utf-8-bom-sample.csv', 'utf8');
+		var csvStream = readStream.pipe(Papa.parse(Papa.NODE_STREAM_INPUT, { header: true }));
+		csvStream.on('data', function(item) {
+			data.push(item);
+		});
+		csvStream.on('end', function() {
+			assert.deepEqual(data[0], { A: 'X', B: 'Y', C: 'Z' });
+			done();
+		});
+	});
+
+	it('keeps a BOM character that is not at the start of the input', function(done) {
+		// Only a leading mark is an encoding artifact; anywhere else it is data.
+		Papa.parse('A,B\nX,\ufeffY', {
+			complete: function(parsedCsv) {
+				assert.deepEqual(parsedCsv.data[1], ['X', '\ufeffY']);
+				done();
+			}
+		});
+	});
 });


### PR DESCRIPTION
The UTF-8 byte order mark is stripped from string input only. Every other input reaches the parser through `ChunkStreamer.parseChunk`, which never sees `stripBom`, so the mark stays inside the first field of the first row:

```js
const readStream = fs.createReadStream('utf-8-bom-sample.csv', 'utf8');
readStream.pipe(Papa.parse(Papa.NODE_STREAM_INPUT))
  .on('data', row => console.log(row));

// ['﻿A', 'B', 'C']   expected ['A', 'B', 'C']
```

Same for a `File`, a `download`, and a Node `Readable`. Nothing renders the character, so the first field simply never compares equal to what it looks like — `row[0] === 'A'` is false, and a `dynamicTyping` number in that position stays a string.

`CsvToJson` strips it at

https://github.com/mholt/PapaParse/blob/master/papaparse.js#L148

but that branch is guarded by `typeof _input === 'string'`.

### Why it has not shown up

`header: true` hides it. 08265f1 added a separate `stripBom` for column keys, so the header row is cleaned wherever it comes from, and only `header: false` is left exposed.

The existing coverage misses it for the same reason the bug is easy to miss. Both BOM cases in `test-cases.js` pass a string literal, and `tests/utf-8-bom-sample.csv` — a fixture that exists precisely for this — is only ever read into a string before being handed to `Papa.parse`. The streaming path has no BOM coverage at all.

### The change

Strip it once at the front of the stream, in the first-chunk block of `parseChunk`, which is where every input path converges. Doing it per streamer would mean four copies.

A mark anywhere other than the very start is data and is left alone.

### Tests

Three added to `tests/node-tests.js`, using the existing fixture through the pipe idiom already used there.

Worth being explicit about which one does the work: only **"strips the utf-8 BOM from a piped stream"** fails without the change. The `header: true` variant passes either way — it is there to document that the header path was already handled by 08265f1 — and "keeps a BOM character that is not at the start of the input" is a guard against over-stripping. `npm run lint && npm run test-node` gives 253 passing.

`papaparse.min.js` is left untouched, since it does not appear in contributor commits.
