### PR TITLE
Add Authier to People Papa

### DIFF
--- a/docs/resources/js/lovers.js
+++ b/docs/resources/js/lovers.js
@@ -122,6 +122,11 @@ var peopleLovePapa = [
 		quote: "Papa makes it easy for our users to customize CSV parsing to match their business logic."
 	},
 	{
+		link: "https://www.authier.pm/",
+		name: "Authier",
+		description: "is an open-source password manager that uses Papa Parse for client-side CSV credential imports and CSV exports of credentials and TOTP records."
+	},
+	{
 		link: "https://www.hellodata.ai/",
 		name: "HelloData",
 		description: "Automatic rent surveys with real-time data on over 25M multifamily units nationwide, direct from property websites.",


### PR DESCRIPTION
## Summary

- add Authier to the People Papa showcase
- describe its client-side CSV credential import and export use
- link the canonical Authier homepage

I maintain Authier. Its released browser extension pins Papa Parse 5.5.4, calls `parse` for CSV credential imports, and calls `unparse` for CSV credential and TOTP exports. Authier is AGPL-licensed open source with a non-expiring free tier and optional paid capacity.

Production-use evidence:

- [released dependency](https://github.com/authier-pm/authier/blob/v1.2.10-extension/web-extension/package.json#L90)
- [credential import](https://github.com/authier-pm/authier/blob/v1.2.10-extension/web-extension/src/pages-vault/VaultImportExport.tsx#L80)
- [credential and TOTP exports](https://github.com/authier-pm/authier/blob/v1.2.10-extension/web-extension/src/components/vault/ExportCsvButtons.tsx#L16-L48)

## Validation

- JavaScript syntax check
- showcase entry and duplicate validation
- `npm run lint`
- `npm run test-node` (255 passing, 25 pending)
- local homepage visual verification

The optional testimonial field is deliberately omitted; the entry makes only factual production-use claims.