### PR TITLE
Run worker script in strict mode to prevent config shadowing

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -49,7 +49,14 @@ License: MIT
 	function getWorkerBlob() {
 		var URL = global.URL || global.webkitURL || null;
 		var code = moduleFactory.toString();
-		return Papa.BLOB_URL || (Papa.BLOB_URL = URL.createObjectURL(new Blob(["var global = (function() { if (typeof self !== 'undefined') { return self; } if (typeof window !== 'undefined') { return window; } if (typeof global !== 'undefined') { return global; } return {}; })(); global.IS_PAPA_WORKER=true; ", '(', code, ')();'], {type: 'text/javascript'})));
+		// The leading 'use strict' pins the worker script to strict mode. Without it the
+		// blob runs as a sloppy-mode classic worker, so Annex B.3.3 hoists a function
+		// declared inside a block up to the enclosing function as an (initially undefined)
+		// var. When a minifier renames that inner function to the same identifier as the
+		// enclosing _config parameter, the hoisted var shadows _config and reads such as
+		// _config.skipEmptyLines throw "Cannot read properties of undefined". Strict mode
+		// keeps the inner function block-scoped, so no shadowing occurs.
+		return Papa.BLOB_URL || (Papa.BLOB_URL = URL.createObjectURL(new Blob(["'use strict'; var global = (function() { if (typeof self !== 'undefined') { return self; } if (typeof window !== 'undefined') { return window; } if (typeof global !== 'undefined') { return global; } return {}; })(); global.IS_PAPA_WORKER=true; ", '(', code, ')();'], {type: 'text/javascript'})));
 	}
 
 	var IS_WORKER = !global.document && !!global.postMessage,

--- a/tests/test-cases.js
+++ b/tests/test-cases.js
@@ -1836,6 +1836,60 @@ describe('Parse Async Tests', function() {
 });
 
 
+// The worker runs a classic (non-module) script built from moduleFactory.toString().
+// If that script runs in sloppy mode, Annex B.3.3 hoists a function declared inside a
+// block up to the enclosing function as an initially-undefined var; when a minifier
+// renames that inner function to the same identifier as the enclosing _config
+// parameter, the hoisted var shadows _config and reads such as _config.skipEmptyLines
+// throw "Cannot read properties of undefined (reading 'skipEmptyLines')" in the worker.
+// getWorkerBlob() therefore pins the whole worker script to strict mode. These tests
+// guard that invariant. The unminified papaparse.js used by this suite has no colliding
+// identifiers, so a plain worker parse cannot reproduce the crash - only the strict
+// prologue can be asserted directly.
+describe('Worker strict mode', function() {
+	var WORKERS_SUPPORTED = typeof Worker !== 'undefined' && typeof URL !== 'undefined' && typeof URL.createObjectURL === 'function';
+
+	(WORKERS_SUPPORTED ? it : it.skip)('generated worker script is pinned to strict mode', function(done) {
+		// Parsing with worker: true lazily creates the blob; capture its URL, fetch the
+		// source and assert the very first statement is a "use strict" directive so the
+		// bootstrap that runs outside moduleFactory cannot fall back to sloppy mode.
+		Papa.parse('A,B,C\nX,Y,Z', {
+			worker: true,
+			complete: function() {
+				assert.isString(Papa.BLOB_URL, 'a worker blob URL should have been created');
+				fetch(Papa.BLOB_URL).then(function(response) {
+					return response.text();
+				}).then(function(code) {
+					assert.match(code, /^\s*(['"])use strict\1\s*;/, 'worker script must begin with a "use strict" directive');
+					done();
+				}).catch(done);
+			},
+			error: function(err) {
+				done(err instanceof Error ? err : new Error(String(err)));
+			}
+		});
+	});
+
+	// A worker parse that walks the header de-duplication path (the code the crashing
+	// build faulted on) together with skipEmptyLines - the exact production shape.
+	(WORKERS_SUPPORTED ? it : it.skip)('parses headers and skips empty lines in a worker without throwing', function(done) {
+		Papa.parse('Col,Col,Value\r\n\r\na,b,1\r\n', {
+			worker: true,
+			header: true,
+			skipEmptyLines: true,
+			complete: function(results) {
+				assert.deepEqual(results.errors, []);
+				assert.deepEqual(results.data, [{Col: 'a', Col_1: 'b', Value: '1'}]);
+				done();
+			},
+			error: function(err) {
+				done(err instanceof Error ? err : new Error(String(err)));
+			}
+		});
+	});
+});
+
+
 
 // Tests for Papa.unparse() function (JSON to CSV)
 var UNPARSE_TESTS = [


### PR DESCRIPTION
N.B. the PR here is pure claude slop. In particular that unit test is of questionable utility, feel free to kill it.

Ultimately this was from a real issue we hit upgrading to 5.7.0. We use vite/esbuild and run PapaParse with `worker: true`

**Summary**

Parsing with worker: true can throw TypeError: Cannot read properties of undefined (reading 'skipEmptyLines') inside the worker when Papa Parse is consumed through a bundler such as Vite/esbuild. The parse dies silently — a Blob
worker's uncaught errors aren't observable to the page, so no error callback fires and nothing reaches Sentry-style reporters. This pins the generated worker script to strict mode, which removes the root cause.

**Root cause**

The worker script is built from moduleFactory.toString() and run as a classic worker via a Blob URL. Three things line up:

1. Sloppy mode. When a bundler inlines Papa Parse into an ES module, it strips the now-redundant module-body 'use strict'. The stringified moduleFactory therefore executes in the Blob worker as a sloppy-mode classic script.
2. Annex B.3.3 hoisting. In sloppy mode, a function declared inside a block is hoisted to the enclosing function as an initially-undefined var. addHeader is declared inside a block within processResults/fillHeaderFields.
3. Name collision. When the bundler re-minifies, it can rename that inner addHeader to the same single-letter identifier as the enclosing ParserHandle _config parameter (both became e in my repro). The hoisted var then shadows
   _config, so processResults() reads _config.skipEmptyLines off undefined before the block assigns it.

The source is correct under strict mode — the inner function stays block-scoped and never shadows _config. The fault only appears once the worker runs sloppy. Note the shipped papaparse.min.js is not itself broken; it runs fine in
a worker standalone. The collision is introduced by a downstream bundler re-minifying, and it's version-sensitive: simplifying addHeader in #1130 shifted the minifier's identifier allocation into the collision (5.6.0 did not
collide; 5.7.0 does).